### PR TITLE
Add Agent model

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,0 +1,6 @@
+class Agent < ApplicationRecord
+  validates :name, presence: true
+  validates :docker_image, presence: true
+  validates :agent_prompt, presence: true
+  validates :setup_script, presence: true
+end

--- a/db/migrate/20250524221353_create_agents.rb
+++ b/db/migrate/20250524221353_create_agents.rb
@@ -1,0 +1,14 @@
+class CreateAgents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :agents do |t|
+      t.string :name
+      t.string :docker_image
+      t.text :agent_prompt
+      t.text :setup_script
+      t.json :start_arguments
+      t.json :continue_arguments
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_24_221353) do
+  create_table "agents", force: :cascade do |t|
+    t.string "name"
+    t.string "docker_image"
+    t.text "agent_prompt"
+    t.text "setup_script"
+    t.json "start_arguments"
+    t.json "continue_arguments"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/test/fixtures/agents.yml
+++ b/test/fixtures/agents.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: Example Agent
+  docker_image: example/image:latest
+  agent_prompt: Example prompt
+  setup_script: example setup
+  start_arguments: {}
+  continue_arguments: {}
+
+two:
+  name: Other Agent
+  docker_image: other/image:latest
+  agent_prompt: Other prompt
+  setup_script: other setup
+  start_arguments: {}
+  continue_arguments: {}

--- a/test/models/agent_test.rb
+++ b/test/models/agent_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class AgentTest < ActiveSupport::TestCase
+  test "fixture is valid" do
+    agent = agents(:one)
+    assert agent.valid?
+  end
+
+  test "requires name and docker image" do
+    agent = Agent.new(agent_prompt: "prompt", setup_script: "script", start_arguments: {}, continue_arguments: {})
+    assert_not agent.valid?
+    assert_includes agent.errors[:name], "can't be blank"
+    assert_includes agent.errors[:docker_image], "can't be blank"
+  end
+end


### PR DESCRIPTION
## Summary
- create Agent model with name, docker image, prompt, setup script, and json argument fields
- validate key fields on Agent
- add minitest coverage for Agent

## Testing
- `bundle exec rake test`
