### PR TITLE
Add worktrees dir and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@
 .devenv*
 devenv.local.nix
 vendor/bundle
+
+# Local worktrees used by parallel agents
+/worktrees/*
+!/worktrees/.keep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,5 +18,9 @@ This is a rails project using the default stack:
 # Git
 - Never put yourself as co-author.
 
+# Worktrees
+- A `/worktrees` directory exists for agent-specific worktrees. Only the `.keep`
+  file is tracked; everything else is ignored so agents can work in parallel.
+
 # Github
 - On all PRs, if you aree claude add the claude label, if you are codex, add the codex label.


### PR DESCRIPTION
## Summary
- ignore the new `worktrees` directory and keep only `.keep`
- document how `worktrees` can be used by multiple agents

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager`