### PR TITLE
Remove host configuration from Kamal proxy

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -19,7 +19,6 @@ servers:
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: false
-  host: summoncircle
 
 logging:
   driver: journald


### PR DESCRIPTION
## Summary
• Removes `host: summoncircle` from Kamal proxy configuration
• All traffic now routes directly to the app without host-based filtering

## Test plan
- [x] Tests pass (8/8)
- [x] Linter passes with no offenses
- [x] Security analysis shows no warnings
- [x] Configuration syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)