### PR TITLE
Add agents CRUD controller

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -1,0 +1,48 @@
+class AgentsController < ApplicationController
+  before_action :set_agent, only: %i[show edit update destroy]
+
+  def index
+    @agents = Agent.all
+  end
+
+  def show
+  end
+
+  def new
+    @agent = Agent.new
+  end
+
+  def create
+    @agent = Agent.new(agent_params)
+    if @agent.save
+      redirect_to @agent, notice: "Agent was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @agent.update(agent_params)
+      redirect_to @agent, notice: "Agent was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @agent.destroy
+    redirect_to agents_url, notice: "Agent was successfully destroyed."
+  end
+
+  private
+    def set_agent
+      @agent = Agent.find(params[:id])
+    end
+
+    def agent_params
+      params.require(:agent).permit(:name, :docker_image, :agent_prompt, :setup_script, start_arguments: {}, continue_arguments: {})
+    end
+end

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -1,0 +1,46 @@
+<%= form_with(model: agent) do |form| %>
+  <% if agent.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(agent.errors.count, "error") %> prohibited this agent from being saved:</h2>
+      <ul>
+        <% agent.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name %><br>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.label :docker_image %><br>
+    <%= form.text_field :docker_image %>
+  </div>
+
+  <div>
+    <%= form.label :agent_prompt %><br>
+    <%= form.text_area :agent_prompt %>
+  </div>
+
+  <div>
+    <%= form.label :setup_script %><br>
+    <%= form.text_area :setup_script %>
+  </div>
+
+  <div>
+    <%= form.label :start_arguments %><br>
+    <%= form.text_area :start_arguments %>
+  </div>
+
+  <div>
+    <%= form.label :continue_arguments %><br>
+    <%= form.text_area :continue_arguments %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/agents/edit.html.erb
+++ b/app/views/agents/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Edit Agent</h1>
+
+<%= render 'form', agent: @agent %>
+
+<%= link_to 'Back', agents_path %>

--- a/app/views/agents/index.html.erb
+++ b/app/views/agents/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Agents</h1>
+
+<%= link_to 'New Agent', new_agent_path %>
+
+<ul>
+  <% @agents.each do |agent| %>
+    <li>
+      <%= link_to agent.name, agent_path(agent) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/agents/new.html.erb
+++ b/app/views/agents/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Agent</h1>
+
+<%= render 'form', agent: @agent %>
+
+<%= link_to 'Back', agents_path %>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -1,0 +1,14 @@
+<h1><%= @agent.name %></h1>
+
+<p>
+  Docker Image: <%= @agent.docker_image %>
+</p>
+
+<h2>Prompt</h2>
+<pre><code><%= @agent.agent_prompt %></code></pre>
+
+<h2>Setup Script</h2>
+<pre><code><%= @agent.setup_script %></code></pre>
+
+<%= link_to 'Edit', edit_agent_path(@agent) %> |
+<%= link_to 'Back', agents_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
+  resources :agents
   resources :projects
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/test/controllers/agents_controller_test.rb
+++ b/test/controllers/agents_controller_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class AgentsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @agent = agents(:one)
+    @user = users(:one)
+  end
+
+  test "index requires authentication" do
+    get agents_url
+    assert_redirected_to new_session_path
+
+    login @user
+    get agents_url
+    assert_response :success
+  end
+
+  test "new requires authentication" do
+    get new_agent_url
+    assert_redirected_to new_session_path
+
+    login @user
+    get new_agent_url
+    assert_response :success
+  end
+
+  test "create requires authentication" do
+    post agents_url, params: { agent: { name: "Test", docker_image: "img", agent_prompt: "prompt", setup_script: "setup" } }
+    assert_redirected_to new_session_path
+
+    login @user
+    assert_difference("Agent.count") do
+      post agents_url, params: { agent: { name: "Test", docker_image: "img", agent_prompt: "prompt", setup_script: "setup" } }
+    end
+    assert_redirected_to agent_path(Agent.last)
+  end
+
+  test "show requires authentication" do
+    get agent_url(@agent)
+    assert_redirected_to new_session_path
+
+    login @user
+    get agent_url(@agent)
+    assert_response :success
+  end
+
+  test "edit requires authentication" do
+    get edit_agent_url(@agent)
+    assert_redirected_to new_session_path
+
+    login @user
+    get edit_agent_url(@agent)
+    assert_response :success
+  end
+
+  test "update requires authentication" do
+    patch agent_url(@agent), params: { agent: { name: "Updated" } }
+    assert_redirected_to new_session_path
+
+    login @user
+    patch agent_url(@agent), params: { agent: { name: "Updated" } }
+    assert_redirected_to agent_path(@agent)
+    @agent.reload
+    assert_equal "Updated", @agent.name
+  end
+
+  test "destroy requires authentication" do
+    delete agent_url(@agent)
+    assert_redirected_to new_session_path
+
+    login @user
+    assert_difference("Agent.count", -1) do
+      delete agent_url(@agent)
+    end
+    assert_redirected_to agents_path
+  end
+end


### PR DESCRIPTION
## Summary
- add `AgentsController` with standard CRUD actions
- create agent views and shared form partial
- expose agents resources in routes
- test that agents actions require authentication

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager`