### PR TITLE
Add agents link on dashboard

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,3 +1,4 @@
 <h1>Dashboard</h1>
 
 <%= link_to 'Projects', projects_path %>
+<%= link_to 'Agents', agents_path %>

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -13,5 +13,6 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     get root_url
     assert_response :success
     assert_match projects_path, @response.body
+    assert_match agents_path, @response.body
   end
 end


### PR DESCRIPTION
## Summary
- link agents index from the dashboard
- expect agents link in dashboard controller test

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager`