### PR TITLE
Add notice/alert flash message system

### DIFF
--- a/app/assets/stylesheets/flash-alert.css
+++ b/app/assets/stylesheets/flash-alert.css
@@ -1,0 +1,60 @@
+:root {
+  --color-success-light: #d4edda;
+  --color-success-dark: #155724;
+  --color-danger-light: #f8d7da;
+  --color-danger-dark: #721c24;
+  --border-radius: 0.375rem;
+  --layout-gutter: 0.75rem;
+  --font-weight-bold: 600;
+}
+
+.flash-alert {
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--border-radius);
+
+  color: var(--fg-color);
+  background-color: var(--bg-color);
+  border-color: var(--fg-color);
+
+  margin-top: var(--layout-gutter);
+  margin-bottom: var(--layout-gutter);
+  padding: var(--layout-gutter);
+}
+
+.flash-alert a {
+  font-weight: var(--font-weight-bold);
+}
+
+.flash-alert > .close {
+  cursor: pointer;
+  padding: var(--layout-gutter);
+  padding-right: calc(var(--layout-gutter) * 1.5);
+  margin-top: calc(var(--layout-gutter) * -1);
+  margin-bottom: calc(var(--layout-gutter) * -1);
+  margin-right: calc(var(--layout-gutter) * -1);
+  float: right;
+  background: transparent;
+  border: 0;
+  color: inherit;
+}
+
+.flash-alert > .close:active,
+.flash-alert > .close:not(:disabled):not(.disabled):active,
+.flash-alert > .close:focus,
+.flash-alert > .close:hover {
+  background: transparent;
+  border: 0;
+  color: inherit;
+}
+
+.flash-alert.-success {
+  --bg-color: var(--color-success-light);
+  --fg-color: var(--color-success-dark);
+}
+
+.flash-alert.-danger {
+  --bg-color: var(--color-danger-light);
+  --fg-color: var(--color-danger-dark);
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,18 @@ module ApplicationHelper
       content_tag(:span, text)
     end
   end
+
+  def flash_message(message, type: "secondary")
+    return nil if message.blank?
+
+    tag.div(
+      class: [ "flash-alert", "-#{type}" ].join(" "),
+      'data-controller': "alert",
+      'data-target': "alert",
+      'data-alert-close-btn-class': "close",
+      role: "alert"
+    ) do
+      message
+    end
+  end
 end

--- a/app/javascript/controllers/alert_controller.js
+++ b/app/javascript/controllers/alert_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["alert"]
+  static classes = [ "closeBtn" ]
+
+  connect() {
+    if(!this.element.querySelector(`.${this.closeBtnClass}`)){
+      const $btn = document.createElement("button");
+      $btn.innerHTML = "&times;";
+      $btn.classList.add(this.closeBtnClass);
+      $btn.setAttribute("aria-hidden", true);
+      $btn.addEventListener("click", this.dismiss.bind(this));
+
+      this.element.prepend($btn);
+    }
+  }
+
+  dismiss(event) {
+    this.element.remove();
+  }
+}

--- a/app/views/application/_flash_messages.html.erb
+++ b/app/views/application/_flash_messages.html.erb
@@ -1,0 +1,2 @@
+<%= flash_message notice, type: "success" %>
+<%= flash_message alert, type: "danger" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,9 @@
   </head>
 
   <body>
+    <div id="flash-messages">
+      <%= render 'flash_messages' %>
+    </div>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add dismissible flash message system matching beankeeper implementation
- Support for notice (success) and alert (danger) message types with proper styling

## Test plan
- [x] All tests pass
- [x] Linter passes with no offenses  
- [x] Security analysis shows no vulnerabilities
- [x] Flash messages display correctly in layout
- [x] Messages are dismissible via close button

🤖 Generated with [Claude Code](https://claude.ai/code)