### PR TITLE
Add Simple.css and navigation bar

### DIFF
--- a/app/views/application/_nav.html.erb
+++ b/app/views/application/_nav.html.erb
@@ -1,0 +1,9 @@
+<header>
+  <nav>
+    <ul>
+      <li><%= link_to "SummonCircle", root_path, class: (current_page?(root_path) ? "current" : nil) %></li>
+      <li><%= link_to "Projects", projects_path, class: (current_page?(projects_path) ? "current" : nil) %></li>
+      <li><%= link_to "Agents", agents_path, class: (current_page?(agents_path) ? "current" : nil) %></li>
+    </ul>
+  </nav>
+</header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,12 +17,17 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
+    <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
+    
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <%= yield %>
+    <%= render "nav" %>
+    <main>
+      <%= yield %>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add Simple.css via CDN for clean, semantic styling inspired by Monday project
- Create minimal navigation structure with SummonCircle, Projects, and Agents links
- Implement current page highlighting using Simple.css conventions

## Implementation Details
- Added Simple.css CDN link to application layout
- Created navigation partial in `app/views/application/_nav.html.erb`
- Updated layout to render navigation and wrap content in semantic `<main>` tag
- Follows Monday project's approach of minimal, semantic HTML with Simple.css defaults

## Test plan
- [x] All tests pass
- [x] Linter passes with no offenses
- [x] Security analysis shows no warnings
- [x] Navigation renders correctly with proper semantic structure
- [x] Current page highlighting works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)