### PR TITLE
Allow agent creation without prompt or script

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -3,6 +3,4 @@ class Agent < ApplicationRecord
 
   validates :name, presence: true
   validates :docker_image, presence: true
-  validates :agent_prompt, presence: true
-  validates :setup_script, presence: true
 end

--- a/test/models/agent_test.rb
+++ b/test/models/agent_test.rb
@@ -12,4 +12,9 @@ class AgentTest < ActiveSupport::TestCase
     assert_includes agent.errors[:name], "can't be blank"
     assert_includes agent.errors[:docker_image], "can't be blank"
   end
+
+  test "prompt and script are optional" do
+    agent = Agent.new(name: "Name", docker_image: "img")
+    assert_valid agent
+  end
 end


### PR DESCRIPTION
## Summary
- make `agent_prompt` and `setup_script` optional
- keep existing controller test with prompt and script
- add a model test validating they are optional

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` (version notice)

Labels: codex