### PR TITLE
Add tidewave gem to development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "tidewave"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,35 @@ GEM
       multi_json
     dotenv (3.1.8)
     drb (2.2.3)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-initializer (3.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-schema (1.14.1)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.5)
+      dry-types (~> 1.8)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.2)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
     erb (5.0.1)
     erubi (1.13.1)
@@ -114,6 +143,12 @@ GEM
       tzinfo
     excon (1.2.5)
       logger
+    fast-mcp (1.3.2)
+      base64
+      dry-schema (~> 1.14)
+      json (~> 2.0)
+      mime-types (~> 3.4)
+      rack (~> 3.1)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -158,6 +193,10 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0520)
     mini_mime (1.1.5)
     minitest (5.25.5)
     mocha (2.7.1)
@@ -341,6 +380,10 @@ GEM
     thruster (0.1.13-arm64-darwin)
     thruster (0.1.13-x86_64-darwin)
     thruster (0.1.13-x86_64-linux)
+    tidewave (0.1.2)
+      fast-mcp (~> 1.3.0)
+      rack (>= 2.0)
+      rails (>= 7.1.0)
     timeout (0.4.3)
     turbo-rails (2.0.13)
       actionpack (>= 7.1.0)
@@ -400,6 +443,7 @@ DEPENDENCIES
   sqlite3 (>= 2.1)
   stimulus-rails
   thruster
+  tidewave
   turbo-rails
   tzinfo-data
   web-console


### PR DESCRIPTION
## Summary
- Add tidewave gem to Gemfile in development group
- Install gem dependencies via bundle install

## Test plan
- [x] All tests pass
- [x] Linter passes with no issues
- [x] Security static analysis shows no vulnerabilities

🤖 Generated with [Claude Code](https://claude.ai/code)