### PR TITLE
Install Mission Control Jobs for admin-only background job monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem "solid_cache"
 gem "solid_queue"
 gem "solid_cable"
 
+# Dashboard for Active Job background jobs
+gem "mission_control-jobs"
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,16 @@ GEM
     mime-types-data (3.2025.0520)
     mini_mime (1.1.5)
     minitest (5.25.5)
+    mission_control-jobs (1.0.2)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
@@ -431,6 +441,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  mission_control-jobs
   mocha
   propshaft
   puma (>= 5.0)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,4 @@
-class MissionControl::Jobs::ApplicationController < ApplicationController
+class AdminController < ApplicationController
   before_action :require_admin
 
   private

--- a/app/controllers/mission_control/jobs/application_controller.rb
+++ b/app/controllers/mission_control/jobs/application_controller.rb
@@ -1,0 +1,9 @@
+class MissionControl::Jobs::ApplicationController < ApplicationController
+  before_action :require_admin
+
+  private
+
+  def require_admin
+    redirect_to root_path unless Current.session&.user&.admin?
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module Summoncircle
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Disable Mission Control Jobs default HTTP basic auth
+    config.mission_control.jobs.http_basic_auth_enabled = false
   end
 end

--- a/config/initializers/mission_control_jobs.rb
+++ b/config/initializers/mission_control_jobs.rb
@@ -1,3 +1,3 @@
 Rails.application.configure do
-  MissionControl::Jobs.base_controller_class = "MissionControl::Jobs::ApplicationController"
+  MissionControl::Jobs.base_controller_class = "AdminController"
 end

--- a/config/initializers/mission_control_jobs.rb
+++ b/config/initializers/mission_control_jobs.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  MissionControl::Jobs.base_controller_class = "MissionControl::Jobs::ApplicationController"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   resources :projects do
     resources :tasks, only: %i[index new create show]
   end
+
+  mount MissionControl::Jobs::Engine, at: "/jobs"
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Summary
- Install Mission Control Jobs gem for Solid Queue dashboard monitoring
- Configure admin-only access using existing user roles and authentication
- Provide web interface at `/jobs` for background job management

## Changes
- Added `mission_control-jobs` gem to Gemfile  
- Mounted Mission Control Jobs engine at `/jobs` route
- Created custom controller requiring admin role for access
- Disabled default HTTP basic auth in favor of existing session-based auth
- Configured Mission Control to use custom authentication controller

## Features
- Web dashboard for monitoring Solid Queue jobs
- View job queues, statuses, and worker information
- Retry/discard failed jobs through UI
- Admin-only access protection
- Integrates with existing user role system

## Testing
- All existing tests pass
- Linter and security scans clean
- Manual testing required in development (Mission Control requires Solid Queue which isn't used in test env)

🤖 Generated with [Claude Code](https://claude.ai/code)