### PR TITLE
Add agent volume management feature

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,8 +1,11 @@
 class Agent < ApplicationRecord
   has_many :tasks, dependent: :destroy
+  has_many :volumes, dependent: :destroy
 
   validates :name, presence: true
   validates :docker_image, presence: true
+
+  attr_accessor :volumes_config
 
   def start_arguments=(value)
     parsed = value.is_a?(String) && value.present? ? JSON.parse(value) : value

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,10 +2,20 @@ class Task < ApplicationRecord
   belongs_to :project
   belongs_to :agent
   has_many :runs, dependent: :destroy
+  has_many :volume_mounts, dependent: :destroy
 
   def run(prompt)
     run = runs.create!(prompt: prompt)
+    create_volume_mounts
     RunJob.perform_later(run.id)
     run
+  end
+
+  private
+
+  def create_volume_mounts
+    agent.volumes.each do |volume|
+      volume_mounts.find_or_create_by!(volume: volume)
+    end
   end
 end

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -1,0 +1,7 @@
+class Volume < ApplicationRecord
+  belongs_to :agent
+  has_many :volume_mounts, dependent: :destroy
+
+  validates :name, presence: true
+  validates :path, presence: true
+end

--- a/app/models/volume_mount.rb
+++ b/app/models/volume_mount.rb
@@ -1,0 +1,6 @@
+class VolumeMount < ApplicationRecord
+  belongs_to :volume
+  belongs_to :task
+
+  validates :volume_id, uniqueness: { scope: :task_id }
+end

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -41,6 +41,11 @@
   </div>
 
   <div>
+    <%= form.label :volumes_config, "Volumes (JSON format)" %><br>
+    <%= form.text_area :volumes_config %>
+  </div>
+
+  <div>
     <%= form.submit %>
   </div>
 <% end %>

--- a/db/migrate/20250528010412_create_volumes.rb
+++ b/db/migrate/20250528010412_create_volumes.rb
@@ -1,0 +1,11 @@
+class CreateVolumes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :volumes do |t|
+      t.string :name
+      t.string :path
+      t.references :agent, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250528010426_create_volume_mounts.rb
+++ b/db/migrate/20250528010426_create_volume_mounts.rb
@@ -1,0 +1,10 @@
+class CreateVolumeMounts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :volume_mounts do |t|
+      t.references :volume, null: false, foreign_key: true
+      t.references :task, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_25_021550) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_28_010426) do
   create_table "agents", force: :cascade do |t|
     t.string "name"
     t.string "docker_image"
@@ -73,8 +73,29 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_25_021550) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  create_table "volume_mounts", force: :cascade do |t|
+    t.integer "volume_id", null: false
+    t.integer "task_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_volume_mounts_on_task_id"
+    t.index ["volume_id"], name: "index_volume_mounts_on_volume_id"
+  end
+
+  create_table "volumes", force: :cascade do |t|
+    t.string "name"
+    t.string "path"
+    t.integer "agent_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["agent_id"], name: "index_volumes_on_agent_id"
+  end
+
   add_foreign_key "runs", "tasks"
   add_foreign_key "sessions", "users"
   add_foreign_key "tasks", "agents"
   add_foreign_key "tasks", "projects"
+  add_foreign_key "volume_mounts", "tasks"
+  add_foreign_key "volume_mounts", "volumes"
+  add_foreign_key "volumes", "agents"
 end

--- a/test/fixtures/volume_mounts.yml
+++ b/test/fixtures/volume_mounts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  volume: one
+  task: one
+
+two:
+  volume: two
+  task: two

--- a/test/fixtures/volumes.yml
+++ b/test/fixtures/volumes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  path: MyString
+  agent: one
+
+two:
+  name: MyString
+  path: MyString
+  agent: two

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -39,10 +39,17 @@ class RunTest < ActiveSupport::TestCase
   end
 
   test "execute! calls Docker container methods correctly for first run" do
+    # Create a fresh agent with no volumes
+    agent = Agent.create!(
+      name: "Test Agent",
+      docker_image: "example/image:latest",
+      start_arguments: [ "echo", "STARTING: {PROMPT}" ],
+      continue_arguments: [ "{PROMPT}" ]
+    )
     # Create a fresh task with no runs
     task = Task.create!(
       project: projects(:one),
-      agent: agents(:one),
+      agent: agent,
       status: "active",
       started_at: Time.current
     )
@@ -57,7 +64,7 @@ class RunTest < ActiveSupport::TestCase
       "Cmd" => [ "echo", "STARTING: test command" ],  # start_arguments with substitution
       "WorkingDir" => "/workspace",
       "HostConfig" => {
-        "Binds" => [ "task_#{task.id}_volume:/workspace" ]
+        "Binds" => []
       }
     ).returns(mock_container)
 
@@ -87,7 +94,7 @@ class RunTest < ActiveSupport::TestCase
       "Cmd" => [ "echo hello" ],  # continue_arguments: ["{PROMPT}"] with "echo hello"
       "WorkingDir" => "/workspace",
       "HostConfig" => {
-        "Binds" => [ "task_#{task.id}_volume:/workspace" ]
+        "Binds" => [ "MyString_#{task.id}_volume:MyString" ]
       }
     ).returns(mock_container)
 

--- a/test/models/volume_mount_test.rb
+++ b/test/models/volume_mount_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class VolumeMountTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/volume_test.rb
+++ b/test/models/volume_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class VolumeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary
- Add ability to define custom volumes for agents that persist across task runs
- Volumes are defined per agent and mounted per task with unique naming
- Supports multiple volumes per agent via JSON configuration

## Changes
- Created `Volume` model to track agent-specific volumes with name and path
- Created `VolumeMount` model to associate volumes with tasks
- Added volumes_config textarea to agent form for JSON input
- Parse JSON to create/update volumes on agent save
- Automatically create volume mounts when starting a task run
- Bind volumes to Docker containers with task-specific naming (format: `{volume_name}_{task_id}_volume`)
- Removed default workspace volume binding to give full control over mounts

## Usage
Volumes are specified in JSON format in the agent form:
```json
{
  "volume_name": "/path/in/container",
  "another_volume": "/another/path"
}
```

## Test plan
- [x] All existing tests pass
- [x] Rubocop linting passes
- [x] Brakeman security analysis shows no issues
- [ ] Create an agent with volume configuration
- [ ] Run a task and verify volumes are mounted correctly
- [ ] Update agent volumes and verify changes take effect