### PR TITLE
Add log processor display to agent show page

### DIFF
--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -10,6 +10,10 @@
 </p>
 <% end %>
 
+<p>
+  Log Processor: <%= @agent.log_processor %>
+</p>
+
 <h2>Prompt</h2>
 <pre><code><%= @agent.agent_prompt %></code></pre>
 


### PR DESCRIPTION
## Summary
• Add log processor field display on agent#show page
• Shows the configured log processor type (Text, ClaudeStreamingJson, etc.)

## Test plan
- [x] Run tests and linter - all pass
- [x] Run security analysis - no issues
- [x] Verify UI displays log processor field correctly

🤖 Generated with [Claude Code](https://claude.ai/code)