### PR TITLE
Fix Claude Stream agent to use streaming log processor

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,7 @@ if Rails.env.development?
     agent.docker_image = "claude_max:latest"
     agent.start_arguments = [ "--dangerously-skip-permissions", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
     agent.continue_arguments = [ "-c", "--dangerously-skip-permissions", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
+    agent.log_processor = "ClaudeStreamingJson"
   end
 
   Volume.find_or_create_by!(agent: claude_stream_agent, name: "workspace") do |volume|


### PR DESCRIPTION
## Summary
- Set Claude Stream agent to use ClaudeStreamingJson processor instead of default Text processor
- Fixes mismatch between agent's JSON output configuration and log processor

## Test plan
- [x] Tests pass
- [x] Linter passes  
- [x] Security analysis passes

🤖 Generated with [Claude Code](https://claude.ai/code)