### PR TITLE
Add sticky agent selection using cookies

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,11 +12,13 @@ class TasksController < ApplicationController
 
   def new
     @task = @project.tasks.new
+    @task.agent_id = cookies[:preferred_agent_id] if cookies[:preferred_agent_id].present?
   end
 
   def create
     @task = @project.tasks.new(task_params)
     if @task.save
+      cookies[:preferred_agent_id] = { value: @task.agent_id, expires: 1.year.from_now }
       @task.update!(started_at: Time.current)
       @task.run(params[:task][:prompt])
       redirect_to [ @project, @task ], notice: "Task was successfully launched."


### PR DESCRIPTION
## Summary
- Remembers the last selected agent when creating new tasks
- Uses browser cookies to store agent preference with 1-year expiration
- Non-intrusive - falls back to default behavior if no cookie exists

## Test plan
- [x] All existing tests pass
- [x] Linter passes with no issues
- [x] Security analysis shows no warnings
- [x] Feature works correctly in both new and returning user scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)