### PR TITLE
Fix ClaudeStreamingJson processor to handle JSON array format

### DIFF
--- a/app/models/log_processor/claude_streaming_json.rb
+++ b/app/models/log_processor/claude_streaming_json.rb
@@ -1,19 +1,15 @@
 class LogProcessor::ClaudeStreamingJson < LogProcessor
   def process(logs)
-    steps = []
+    begin
+      parsed_array = JSON.parse(logs.strip)
 
-    logs.split("\n").each do |line|
-      line = line.strip
-      next if line.empty?
-
-      begin
-        parsed_json = JSON.parse(line)
-        steps << { raw_response: parsed_json }
-      rescue JSON::ParserError
-        steps << { raw_response: line }
+      if parsed_array.is_a?(Array)
+        parsed_array.map { |item| { raw_response: item } }
+      else
+        [ { raw_response: parsed_array } ]
       end
+    rescue JSON::ParserError
+      [ { raw_response: logs } ]
     end
-
-    steps.empty? ? [ { raw_response: logs } ] : steps
   end
 end

--- a/test/models/log_processor/claude_streaming_json_test.rb
+++ b/test/models/log_processor/claude_streaming_json_test.rb
@@ -1,11 +1,9 @@
 require "test_helper"
 
 class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
-  test "process parses valid JSON lines into separate steps" do
+  test "process parses JSON array into separate steps" do
     processor = LogProcessor::ClaudeStreamingJson.new
-    logs = '{"type": "system", "message": "Starting"}
-{"type": "user", "content": "Hello"}
-{"type": "assistant", "response": "Hi there"}'
+    logs = '[{"type": "system", "message": "Starting"}, {"type": "user", "content": "Hello"}, {"type": "assistant", "response": "Hi there"}]'
 
     result = processor.process(logs)
 
@@ -15,43 +13,37 @@ class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
     assert_equal({ raw_response: { "type" => "assistant", "response" => "Hi there" } }, result[2])
   end
 
-  test "process handles mixed valid and invalid JSON lines" do
+  test "process handles single JSON object" do
     processor = LogProcessor::ClaudeStreamingJson.new
-    logs = '{"type": "system"}
-Invalid JSON line
-{"type": "user", "content": "Hello"}'
+    logs = '{"type": "system", "message": "Starting"}'
 
     result = processor.process(logs)
 
-    assert_equal 3, result.size
-    assert_equal({ raw_response: { "type" => "system" } }, result[0])
-    assert_equal({ raw_response: "Invalid JSON line" }, result[1])
-    assert_equal({ raw_response: { "type" => "user", "content" => "Hello" } }, result[2])
+    assert_equal 1, result.size
+    assert_equal({ raw_response: { "type" => "system", "message" => "Starting" } }, result[0])
   end
 
-  test "process handles empty lines" do
+  test "process handles complex nested JSON from real example" do
     processor = LogProcessor::ClaudeStreamingJson.new
-    logs = '{"type": "system"}
-
-{"type": "user"}'
+    logs = '[{"type":"system","subtype":"init","session_id":"4ae13eec-ff85-4ea2-9d98-64a7cb25e874","tools":["Task","Bash"],"mcp_servers":[]},{"type":"assistant","message":{"id":"e3d7588f-fe40-450b-a83c-c7377cbdacae","model":"<synthetic>","role":"assistant","stop_reason":"stop_sequence","stop_sequence":"","type":"message","usage":{"input_tokens":0,"output_tokens":0},"content":[{"type":"text","text":"API Error: 401"}]},"session_id":"4ae13eec-ff85-4ea2-9d98-64a7cb25e874"}]'
 
     result = processor.process(logs)
 
     assert_equal 2, result.size
-    assert_equal({ raw_response: { "type" => "system" } }, result[0])
-    assert_equal({ raw_response: { "type" => "user" } }, result[1])
+    assert_equal "system", result[0][:raw_response]["type"]
+    assert_equal "assistant", result[1][:raw_response]["type"]
   end
 
-  test "process returns single step for empty or invalid logs" do
+  test "process returns single step for invalid JSON" do
     processor = LogProcessor::ClaudeStreamingJson.new
+
+    result = processor.process("Invalid JSON")
+    assert_equal 1, result.size
+    assert_equal({ raw_response: "Invalid JSON" }, result.first)
 
     result = processor.process("")
     assert_equal 1, result.size
     assert_equal({ raw_response: "" }, result.first)
-
-    result = processor.process("   \n  \n  ")
-    assert_equal 1, result.size
-    assert_equal({ raw_response: "   \n  \n  " }, result.first)
   end
 
   test "class method process works" do

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -244,8 +244,7 @@ class RunTest < ActiveSupport::TestCase
     )
     run = task.runs.create!(prompt: "test")
 
-    logs = '{"type": "system", "message": "Starting"}
-{"type": "user", "content": "Hello"}'
+    logs = '[{"type": "system", "message": "Starting"}, {"type": "user", "content": "Hello"}]'
     run.send(:create_steps_from_logs, logs)
 
     assert_equal 2, run.steps.count


### PR DESCRIPTION
## Summary
- Updated ClaudeStreamingJson processor to parse streaming logs as a single JSON array instead of newline-separated JSON objects
- Each item in the array is now stored as a separate step with its own raw_response field
- Updated tests to match the new expected format