### PR TITLE
Add --model sonnet to all agent seed commands

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,8 +17,8 @@ if Rails.env.development?
 
   claude_agent = Agent.find_or_create_by!(name: "Claude") do |agent|
     agent.docker_image = "claude_max:latest"
-    agent.start_arguments = [ "--dangerously-skip-permissions", "-p", "{PROMPT}" ]
-    agent.continue_arguments = [ "-c", "--dangerously-skip-permissions", "-p", "{PROMPT}" ]
+    agent.start_arguments = [ "--dangerously-skip-permissions", "--model", "sonnet", "-p", "{PROMPT}" ]
+    agent.continue_arguments = [ "-c", "--dangerously-skip-permissions", "--model", "sonnet", "-p", "{PROMPT}" ]
   end
 
   Volume.find_or_create_by!(agent: claude_agent, name: "workspace") do |volume|
@@ -31,8 +31,8 @@ if Rails.env.development?
 
   claude_stream_agent = Agent.find_or_create_by!(name: "Claude Stream") do |agent|
     agent.docker_image = "claude_max:latest"
-    agent.start_arguments = [ "--dangerously-skip-permissions", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
-    agent.continue_arguments = [ "-c", "--dangerously-skip-permissions", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
+    agent.start_arguments = [ "--dangerously-skip-permissions", "--model", "sonnet", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
+    agent.continue_arguments = [ "-c", "--dangerously-skip-permissions", "--model", "sonnet", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
     agent.log_processor = "ClaudeStreamingJson"
   end
 


### PR DESCRIPTION
## Summary
- Added `--model sonnet` flag to all agent seed commands for both Claude and Claude Stream agents

## Test plan
- Verify seed commands include the new model flag
- Test agent creation uses correct arguments

🤖 Generated with [Claude Code](https://claude.ai/code)