### PR TITLE
Add UUID and app prefix to Docker volume names

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -56,7 +56,7 @@ class Run < ApplicationRecord
 
     task.volume_mounts.includes(:volume).each do |volume_mount|
       volume = volume_mount.volume
-      volume_name = "#{volume.name}_#{task_id}_volume"
+      volume_name = "summoncircle_#{volume.name}_volume_#{SecureRandom.uuid}"
       binds << "#{volume_name}:#{volume.path}"
     end
 

--- a/lib/tasks/volumes.rake
+++ b/lib/tasks/volumes.rake
@@ -1,0 +1,42 @@
+namespace :volumes do
+  desc "Flush all existing Docker volumes with summoncircle prefix"
+  task flush: :environment do
+    require "docker"
+
+    begin
+      volumes = Docker::Volume.all
+      summoncircle_volumes = volumes.select { |volume| volume.info["Name"].start_with?("summoncircle_") }
+
+      if summoncircle_volumes.empty?
+        puts "No summoncircle volumes found."
+        next
+      end
+
+      puts "Found #{summoncircle_volumes.size} summoncircle volumes:"
+      summoncircle_volumes.each { |volume| puts "  - #{volume.info["Name"]}" }
+
+      print "Are you sure you want to delete these volumes? (y/N): "
+      confirmation = $stdin.gets.chomp.downcase
+
+      if confirmation == "y" || confirmation == "yes"
+        summoncircle_volumes.each do |volume|
+          begin
+            volume.delete
+            puts "Deleted: #{volume.info["Name"]}"
+          rescue Docker::Error::ConflictError
+            puts "Volume in use, forcing deletion: #{volume.info["Name"]}"
+            volume.delete(force: true)
+          rescue => e
+            puts "Failed to delete #{volume.info["Name"]}: #{e.message}"
+          end
+        end
+        puts "Volume flush complete."
+      else
+        puts "Volume flush cancelled."
+      end
+    rescue => e
+      puts "Error accessing Docker: #{e.message}"
+      puts "Make sure Docker is running and accessible."
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Replace task_id with UUID in volume names for better uniqueness and avoid conflicts
- Add 'summoncircle_' prefix to all volumes for easier identification and management
- Add `bin/rails volumes:flush` rake task to clean up existing volumes with confirmation prompt

## Test plan
- [x] Run tests and ensure they pass with new volume naming
- [x] Run linter and security analysis 
- [x] Verify rake task works correctly with no existing volumes
- [ ] Test volume creation and mounting with actual Docker containers
- [ ] Test volume flush rake task with existing volumes

🤖 Generated with [Claude Code](https://claude.ai/code)