### PR TITLE
Remove agent prompt and setup script fields

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -51,7 +51,7 @@ class AgentsController < ApplicationController
 
     def agent_params
       params.require(:agent)
-            .permit(:name, :docker_image, :docker_host, :agent_prompt, :setup_script, :start_arguments, :continue_arguments, :volumes_config, :log_processor)
+            .permit(:name, :docker_image, :docker_host, :start_arguments, :continue_arguments, :volumes_config, :log_processor)
     end
 
     def create_volumes_from_config(agent, volumes_config)

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -25,15 +25,6 @@
     <%= form.text_field :docker_host %>
   </div>
 
-  <div>
-    <%= form.label :agent_prompt %><br>
-    <%= form.text_area :agent_prompt %>
-  </div>
-
-  <div>
-    <%= form.label :setup_script %><br>
-    <%= form.text_area :setup_script %>
-  </div>
 
   <div>
     <%= form.label :start_arguments %><br>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -14,12 +14,6 @@
   Log Processor: <%= @agent.log_processor %>
 </p>
 
-<h2>Prompt</h2>
-<pre><code><%= @agent.agent_prompt %></code></pre>
-
-<h2>Setup Script</h2>
-<pre><code><%= @agent.setup_script %></code></pre>
-
 <h2>Start Arguments</h2>
 <pre><code><%= @agent.start_arguments.to_json %></code></pre>
 

--- a/db/migrate/20250531020138_remove_prompt_and_setup_from_agents.rb
+++ b/db/migrate/20250531020138_remove_prompt_and_setup_from_agents.rb
@@ -1,0 +1,6 @@
+class RemovePromptAndSetupFromAgents < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :agents, :agent_prompt, :text
+    remove_column :agents, :setup_script, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_30_025441) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_31_020138) do
   create_table "agents", force: :cascade do |t|
     t.string "name"
     t.string "docker_image"
-    t.text "agent_prompt"
-    t.text "setup_script"
     t.json "start_arguments"
     t.json "continue_arguments"
     t.datetime "created_at", null: false

--- a/test/controllers/agents_controller_test.rb
+++ b/test/controllers/agents_controller_test.rb
@@ -25,19 +25,19 @@ class AgentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create requires authentication" do
-    post agents_url, params: { agent: { name: "Test", docker_image: "img", agent_prompt: "prompt", setup_script: "setup" } }
+    post agents_url, params: { agent: { name: "Test", docker_image: "img" } }
     assert_redirected_to new_session_path
 
     login @user
     assert_difference("Agent.count") do
-      post agents_url, params: { agent: { name: "Test", docker_image: "img", agent_prompt: "prompt", setup_script: "setup" } }
+      post agents_url, params: { agent: { name: "Test", docker_image: "img" } }
     end
     assert_redirected_to agent_path(Agent.last)
   end
 
   test "create persists json arguments" do
     login @user
-    post agents_url, params: { agent: { name: "Args", docker_image: "img", agent_prompt: "prompt", setup_script: "script", start_arguments: "[\"a\", \"b\"]", continue_arguments: "[1]" } }
+    post agents_url, params: { agent: { name: "Args", docker_image: "img", start_arguments: "[\"a\", \"b\"]", continue_arguments: "[1]" } }
     agent = Agent.last
     assert_equal [ "a", "b" ], agent.start_arguments
     assert_equal [ 1 ], agent.continue_arguments

--- a/test/fixtures/agents.yml
+++ b/test/fixtures/agents.yml
@@ -3,15 +3,11 @@
 one:
   name: Example Agent
   docker_image: example/image:latest
-  agent_prompt: Example prompt
-  setup_script: example setup
   start_arguments: ["echo", "STARTING: {PROMPT}"]
   continue_arguments: ["{PROMPT}"]
 
 two:
   name: Other Agent
   docker_image: other/image:latest
-  agent_prompt: Other prompt
-  setup_script: other setup
   start_arguments: ["echo", "{PROMPT}"]
   continue_arguments: ["echo", "CONTINUE: {PROMPT}"]

--- a/test/models/agent_test.rb
+++ b/test/models/agent_test.rb
@@ -7,13 +7,13 @@ class AgentTest < ActiveSupport::TestCase
   end
 
   test "requires name and docker image" do
-    agent = Agent.new(agent_prompt: "prompt", setup_script: "script", start_arguments: {}, continue_arguments: {})
+    agent = Agent.new(start_arguments: {}, continue_arguments: {})
     assert_not agent.valid?
     assert_includes agent.errors[:name], "can't be blank"
     assert_includes agent.errors[:docker_image], "can't be blank"
   end
 
-  test "prompt and script are optional" do
+  test "name and docker image are sufficient" do
     agent = Agent.new(name: "Name", docker_image: "img")
     assert_valid agent
   end


### PR DESCRIPTION
## Summary
• Remove unused agent_prompt and setup_script fields from Agent model
• Clean up controller, views, and tests to remove references to these fields
• Simplify agent configuration by removing unnecessary complexity

🤖 Generated with [Claude Code](https://claude.ai/code)