### PR TITLE
Add Enter/Shift+Enter functionality to prompt textareas

### DIFF
--- a/app/javascript/controllers/prompt_controller.js
+++ b/app/javascript/controllers/prompt_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["textarea"]
+
+  keydown(event) {
+    if (event.key === "Enter") {
+      if (event.shiftKey) {
+        return
+      } else {
+        event.preventDefault()
+        this.submitForm()
+      }
+    }
+  }
+
+  submitForm() {
+    const form = this.textareaTarget.closest("form")
+    if (form) {
+      form.requestSubmit()
+    }
+  }
+}

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -17,9 +17,9 @@
     <%= form.collection_select :agent_id, Agent.all, :id, :name %>
   </div>
 
-  <div>
+  <div data-controller="prompt">
     <%= form.label :prompt %><br>
-    <%= form.text_area :prompt %>
+    <%= form.text_area :prompt, data: { prompt_target: "textarea", action: "keydown->prompt#keydown" } %>
   </div>
 
   <div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -3,10 +3,10 @@
 <p>Agent: <%= @task.agent.name %></p>
 
 <h2>New Run</h2>
-<%= form_with model: [@project, @task, Run.new], url: project_task_runs_path(@project, @task), data: { turbo: false } do |form| %>
+<%= form_with model: [@project, @task, Run.new], url: project_task_runs_path(@project, @task), data: { turbo: false, controller: "prompt" } do |form| %>
   <div>
     <%= form.label :prompt %><br>
-    <%= form.text_area :prompt, required: true, rows: 4, cols: 50 %>
+    <%= form.text_area :prompt, required: true, rows: 4, cols: 50, data: { prompt_target: "textarea", action: "keydown->prompt#keydown" } %>
   </div>
   <div>
     <%= form.submit "Run" %>


### PR DESCRIPTION
## Summary
• Add Enter key to submit prompt forms immediately
• Add Shift+Enter to insert line breaks in prompt textareas

🤖 Generated with [Claude Code](https://claude.ai/code)