### PR TITLE
Rename ClaudeStreamingJson to ClaudeJson processor and agent

### DIFF
--- a/app/models/log_processor.rb
+++ b/app/models/log_processor.rb
@@ -1,7 +1,7 @@
 class LogProcessor
   ALL = [
     LogProcessor::Text,
-    LogProcessor::ClaudeStreamingJson
+    LogProcessor::ClaudeJson
   ].freeze
 
   def self.process(logs)

--- a/app/models/log_processor/claude_json.rb
+++ b/app/models/log_processor/claude_json.rb
@@ -1,4 +1,4 @@
-class LogProcessor::ClaudeStreamingJson < LogProcessor
+class LogProcessor::ClaudeJson < LogProcessor
   def process(logs)
     begin
       parsed_array = JSON.parse(logs.strip)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ if Rails.env.development?
     volume.path = "/home/claude"
   end
 
-  claude_stream_agent = Agent.find_or_create_by!(name: "Claude Stream") do |agent|
+  claude_stream_agent = Agent.find_or_create_by!(name: "Claude Json") do |agent|
     agent.docker_image = "claude_max:latest"
     agent.start_arguments = [ "--dangerously-skip-permissions", "--model", "sonnet", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
     agent.continue_arguments = [ "-c", "--dangerously-skip-permissions", "--model", "sonnet", "--output-format", "json", "--verbose", "-p", "{PROMPT}" ]
-    agent.log_processor = "ClaudeStreamingJson"
+    agent.log_processor = "ClaudeJson"
   end
 
   Volume.find_or_create_by!(agent: claude_stream_agent, name: "workspace") do |volume|

--- a/test/models/agent_test.rb
+++ b/test/models/agent_test.rb
@@ -27,8 +27,8 @@ class AgentTest < ActiveSupport::TestCase
     agent = Agent.new(name: "Name", docker_image: "img", log_processor: "Text")
     assert_equal LogProcessor::Text, agent.log_processor_class
 
-    agent.log_processor = "ClaudeStreamingJson"
-    assert_equal LogProcessor::ClaudeStreamingJson, agent.log_processor_class
+    agent.log_processor = "ClaudeJson"
+    assert_equal LogProcessor::ClaudeJson, agent.log_processor_class
   end
 
   test "log_processor_class raises error for invalid processor" do

--- a/test/models/log_processor/claude_json_test.rb
+++ b/test/models/log_processor/claude_json_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
+class LogProcessor::ClaudeJsonTest < ActiveSupport::TestCase
   test "process parses JSON array into separate steps" do
-    processor = LogProcessor::ClaudeStreamingJson.new
+    processor = LogProcessor::ClaudeJson.new
     logs = '[{"type": "system", "message": "Starting"}, {"type": "user", "content": "Hello"}, {"type": "assistant", "response": "Hi there"}]'
 
     result = processor.process(logs)
@@ -14,7 +14,7 @@ class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
   end
 
   test "process handles single JSON object" do
-    processor = LogProcessor::ClaudeStreamingJson.new
+    processor = LogProcessor::ClaudeJson.new
     logs = '{"type": "system", "message": "Starting"}'
 
     result = processor.process(logs)
@@ -24,7 +24,7 @@ class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
   end
 
   test "process handles complex nested JSON from real example" do
-    processor = LogProcessor::ClaudeStreamingJson.new
+    processor = LogProcessor::ClaudeJson.new
     logs = '[{"type":"system","subtype":"init","session_id":"4ae13eec-ff85-4ea2-9d98-64a7cb25e874","tools":["Task","Bash"],"mcp_servers":[]},{"type":"assistant","message":{"id":"e3d7588f-fe40-450b-a83c-c7377cbdacae","model":"<synthetic>","role":"assistant","stop_reason":"stop_sequence","stop_sequence":"","type":"message","usage":{"input_tokens":0,"output_tokens":0},"content":[{"type":"text","text":"API Error: 401"}]},"session_id":"4ae13eec-ff85-4ea2-9d98-64a7cb25e874"}]'
 
     result = processor.process(logs)
@@ -35,7 +35,7 @@ class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
   end
 
   test "process returns single step for invalid JSON" do
-    processor = LogProcessor::ClaudeStreamingJson.new
+    processor = LogProcessor::ClaudeJson.new
 
     result = processor.process("Invalid JSON")
     assert_equal 1, result.size
@@ -48,7 +48,7 @@ class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
 
   test "class method process works" do
     logs = '{"type": "test"}'
-    result = LogProcessor::ClaudeStreamingJson.process(logs)
+    result = LogProcessor::ClaudeJson.process(logs)
 
     assert_equal 1, result.size
     assert_equal({ raw_response: { "type" => "test" } }, result.first)

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -229,12 +229,12 @@ class RunTest < ActiveSupport::TestCase
     assert_equal logs, run.steps.first.raw_response
   end
 
-  test "create_steps_from_logs with ClaudeStreamingJson processor" do
-    # Create agent with ClaudeStreamingJson processor
+  test "create_steps_from_logs with ClaudeJson processor" do
+    # Create agent with ClaudeJson processor
     agent = Agent.create!(
       name: "JSON Agent",
       docker_image: "example/image:latest",
-      log_processor: "ClaudeStreamingJson",
+      log_processor: "ClaudeJson",
       start_arguments: [ "echo", "test" ]
     )
     task = Task.create!(


### PR DESCRIPTION
## Summary
- Rename log processor from ClaudeStreamingJson to ClaudeJson to better reflect that it processes JSON output rather than streaming JSON
- Update seeded agent name from "Claude Stream" to "Claude Json"
- Update all test references and class names accordingly

🤖 Generated with [Claude Code](https://claude.ai/code)