### PR TITLE
Add parsed_response method to Step model

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,4 +2,10 @@ class Step < ApplicationRecord
   belongs_to :run
 
   validates :raw_response, presence: true
+
+  def parsed_response
+    JSON.parse(raw_response)
+  rescue JSON::ParserError
+    raw_response
+  end
 end

--- a/test/models/step_test.rb
+++ b/test/models/step_test.rb
@@ -39,4 +39,23 @@ class StepTest < ActiveSupport::TestCase
       run.destroy
     end
   end
+
+  test "parsed_response should return parsed JSON" do
+    json_data = { "message" => "hello", "status" => "success" }
+    step = Step.new(
+      run: runs(:one),
+      raw_response: json_data.to_json
+    )
+
+    assert_equal json_data, step.parsed_response
+  end
+
+  test "parsed_response should return raw_response for invalid JSON" do
+    step = Step.new(
+      run: runs(:one),
+      raw_response: "invalid json"
+    )
+
+    assert_equal "invalid json", step.parsed_response
+  end
 end


### PR DESCRIPTION
## Summary
- Add parsed_response method to Step model that safely parses JSON from raw_response
- Returns parsed JSON hash when valid, falls back to raw string when parsing fails
- Comprehensive test coverage for both success and error scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)