### PR TITLE
Add standard user to development seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,12 @@ if Rails.env.development?
     user.role = "admin"
   end
 
+  User.find_or_create_by!(email_address: "user@example.com") do |user|
+    user.password = "password"
+    user.password_confirmation = "password"
+    user.role = "standard"
+  end
+
   claude_agent = Agent.find_or_create_by!(name: "Claude") do |agent|
     agent.docker_image = "claude_max:latest"
     agent.start_arguments = [ "--dangerously-skip-permissions", "--model", "sonnet", "-p", "{PROMPT}" ]


### PR DESCRIPTION
## Summary
- Add a new standard user to development seeds for testing purposes
- Email: user@example.com with password: password
- Role: standard (non-admin user)

🤖 Generated with [Claude Code](https://claude.ai/code)