### PR TITLE
Add reusable form_errors helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def form_errors(instance, **locals)
+    locals[:instance] = instance
+    render partial: "application/form_errors", locals: locals
+  end
+
   def safe_external_link(text, url)
     return content_tag(:span, text) unless url.present?
     return content_tag(:span, text) unless url.start_with?("http://", "https://")

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -1,14 +1,5 @@
 <%= form_with(model: agent) do |form| %>
-  <% if agent.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(agent.errors.count, "error") %> prohibited this agent from being saved:</h2>
-      <ul>
-        <% agent.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= form_errors(agent) %>
 
   <div>
     <%= form.label :name %><br>

--- a/app/views/application/_form_errors.html.erb
+++ b/app/views/application/_form_errors.html.erb
@@ -1,0 +1,17 @@
+<% if instance.errors.any? %>
+  <div class="errors">
+    <h2>
+      <%= t(
+          ".title",
+          count: instance.errors.count,
+          name: (defined?(name) ? name : instance.class.model_name.human).downcase,
+      ) %>
+    </h2>
+
+    <ul>
+      <% instance.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,17 +1,7 @@
 <h1>New Project</h1>
 
 <%= form_with(model: @project) do |form| %>
-  <% if @project.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@project.errors.count, "error") %> prohibited this project from being saved:</h2>
-
-      <ul>
-        <% @project.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= form_errors(@project) %>
 
   <div>
     <%= form.label :name %><br>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,16 +1,7 @@
 <h1>New Task</h1>
 
 <%= form_with(model: [@project, @task]) do |form| %>
-  <% if @task.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
-      <ul>
-        <% @task.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= form_errors(@task) %>
 
   <div>
     <%= form.label :agent_id, "Agent" %><br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,8 @@
 
 en:
   hello: "Hello world"
+  application:
+    form_errors:
+      title:
+        one: An error prohibited this %{name} from being saved
+        other: "%{count} errors prohibited this %{name} from being saved"


### PR DESCRIPTION
## Summary
- Add form_errors helper method to ApplicationHelper for consistent error display
- Replace duplicated error handling code across project, task, and agent forms with reusable helper

🤖 Generated with [Claude Code](https://claude.ai/code)