### PR TITLE
Fix prompt textarea width to match runs section

### DIFF
--- a/app/views/tasks/_run_form.html.erb
+++ b/app/views/tasks/_run_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@project, @task, run], id: "run-form", data: { controller: "prompt", action: "turbo:submit-end->prompt#clearForm" } do |form| %>
   <div>
     <%= form.label :prompt %><br>
-    <%= form.text_area :prompt, required: true, rows: 4, cols: 50, data: { prompt_target: "textarea", action: "keydown->prompt#keydown" } %>
+    <%= form.text_area :prompt, required: true, rows: 4, style: "width: 100%; box-sizing: border-box;", data: { prompt_target: "textarea", action: "keydown->prompt#keydown" } %>
     <% if run.errors.any? %>
       <div style="color: red;">
         <% run.errors.full_messages.each do |message| %>


### PR DESCRIPTION
## Summary
- Remove fixed `cols: 50` constraint from prompt textarea 
- Add full width styling to match runs section above

🤖 Generated with [Claude Code](https://claude.ai/code)