### PR TITLE
Improve mobile enter key behavior for virtual keyboards

### DIFF
--- a/app/javascript/controllers/prompt_controller.js
+++ b/app/javascript/controllers/prompt_controller.js
@@ -3,13 +3,21 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["textarea", "form"]
 
+  connect() {
+    this.updateTextareaAttributes()
+  }
+
   keydown(event) {
     if (event.key === "Enter") {
-      if (event.shiftKey) {
+      if (this.isMobile()) {
         return
       } else {
-        event.preventDefault()
-        this.submitForm()
+        if (event.shiftKey) {
+          return
+        } else {
+          event.preventDefault()
+          this.submitForm()
+        }
       }
     }
   }
@@ -23,5 +31,23 @@ export default class extends Controller {
 
   clearForm() {
     this.textareaTarget.value = ""
+  }
+
+  isMobile() {
+    const userAgent = navigator.userAgent.toLowerCase()
+    const hasTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    const smallScreen = window.matchMedia("(max-width: 768px)").matches
+    
+    const mobileUserAgents = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/
+    
+    return hasTouch && (smallScreen || mobileUserAgents.test(userAgent))
+  }
+
+  updateTextareaAttributes() {
+    if (this.isMobile()) {
+      this.textareaTarget.setAttribute('enterkeyhint', 'enter')
+    } else {
+      this.textareaTarget.setAttribute('enterkeyhint', 'send')
+    }
   }
 }


### PR DESCRIPTION
## Summary
- On mobile devices, Enter key now creates line breaks instead of submitting the form
- Maintains existing Shift+Enter behavior on desktop for backward compatibility
- Adds robust mobile detection using touch capability, screen size, and user agent patterns
- Sets appropriate `enterkeyhint` attributes for better virtual keyboard UX

🤖 Generated with [Claude Code](https://claude.ai/code)