### PR TITLE
Position project and agent selectors side by side

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -32,3 +32,16 @@
   color: #666;
   border-radius: 4px;
 }
+
+.task-form {
+  
+}
+
+.task-form > .selectors {
+  display: flex;
+  gap: 1rem;
+}
+
+.task-form > .selectors > .field {
+  flex: 1;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -32,16 +32,3 @@
   color: #666;
   border-radius: 4px;
 }
-
-.task-form {
-  
-}
-
-.task-form > .selectors {
-  display: flex;
-  gap: 1rem;
-}
-
-.task-form > .selectors > .field {
-  flex: 1;
-}

--- a/app/assets/stylesheets/task-form.css
+++ b/app/assets/stylesheets/task-form.css
@@ -1,0 +1,10 @@
+.task-form {
+  & .selectors {
+    display: flex;
+    gap: 1rem;
+  }
+
+  & .selectors .field {
+    flex: 1;
+  }
+}

--- a/app/views/tasks/_task_form.html.erb
+++ b/app/views/tasks/_task_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @task, local: true) do |form| %>
+<%= form_with(model: @task, local: true, class: "task-form") do |form| %>
   <% if @task.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
@@ -10,14 +10,16 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :project_id, "Project" %><br>
-    <%= form.collection_select :project_id, @projects, :id, :name, { prompt: "Select a project" } %>
-  </div>
+  <div class="selectors">
+    <div class="field">
+      <%= form.label :project_id, "Project" %><br>
+      <%= form.collection_select :project_id, @projects, :id, :name, { prompt: "Select a project" } %>
+    </div>
 
-  <div>
-    <%= form.label :agent_id, "Agent" %><br>
-    <%= form.collection_select :agent_id, @agents, :id, :name, { prompt: "Select an agent" } %>
+    <div class="field">
+      <%= form.label :agent_id, "Agent" %><br>
+      <%= form.collection_select :agent_id, @agents, :id, :name, { prompt: "Select an agent" } %>
+    </div>
   </div>
 
   <div data-controller="prompt">


### PR DESCRIPTION
## Summary
- Replace inline styles with RSCSS-compliant CSS for form layout
- Use flexbox to position project and agent select fields horizontally

🤖 Generated with [Claude Code](https://claude.ai/code)