### PR TITLE
Add error indication for result steps

### DIFF
--- a/app/assets/stylesheets/components/step-result.css
+++ b/app/assets/stylesheets/components/step-result.css
@@ -1,0 +1,19 @@
+.step-result {
+  margin: 5px 0;
+  padding: 5px;
+  background: #d4edda;
+  border-left: 3px solid #28a745;
+}
+
+.step-result.-error {
+  background: #f8d7da;
+  border-left-color: #dc3545;
+}
+
+.step-result > .label {
+  font-weight: bold;
+}
+
+.step-result > .content {
+  margin: 5px 0 0 0;
+}

--- a/app/models/step/result.rb
+++ b/app/models/step/result.rb
@@ -1,2 +1,5 @@
 class Step::Result < Step
+  def error?
+    parsed_response.is_a?(Hash) && parsed_response["is_error"] == true
+  end
 end

--- a/app/views/step/results/_result.html.erb
+++ b/app/views/step/results/_result.html.erb
@@ -1,10 +1,12 @@
+<% icon_and_label = result.error? ? "❌ Result (Error)" : "✅ Result" %>
+
 <% if result.content.present? && result.run.steps.where.not(id: result.id).none? { |s| s.content == result.content } %>
-  <div style="margin: 5px 0; padding: 5px; background: #d4edda; border-left: 3px solid #28a745;">
-    <strong>✅ Result</strong>
-    <pre style="margin: 5px 0 0 0;"><%= result.content %></pre>
+  <div class="<%= class_names("step-result", "-error": result.error?) %>">
+    <div class="label"><%= icon_and_label %></div>
+    <pre class="content"><%= result.content %></pre>
   </div>
 <% else %>
-  <div style="margin: 5px 0; padding: 5px; background: #d4edda; border-left: 3px solid #28a745;">
-    <strong>✅ Result</strong>
+  <div class="<%= class_names("step-result", "-error": result.error?) %>">
+    <div class="label"><%= icon_and_label %></div>
   </div>
 <% end %>

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -96,8 +96,20 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
     get project_task_url(@project, @task)
     assert_response :success
-    assert_select "div strong", text: "✅ Result"
-    assert_select "pre", text: "Task completed successfully"
+    assert_select "div.label", text: "✅ Result"
+    assert_select "pre.content", text: "Task completed successfully"
+  end
+
+  test "show renders Step::Result with error styling when is_error is true" do
+    login @user
+    run = @task.runs.create!(prompt: "test")
+    run.steps.create!(type: "Step::Result", content: "API Error occurred", raw_response: '{"type":"result","is_error":true}')
+
+    get project_task_url(@project, @task)
+    assert_response :success
+    assert_select "div.step-result.-error"
+    assert_select "div.label", text: "❌ Result (Error)"
+    assert_select "pre.content", text: "API Error occurred"
   end
 
   test "show renders Step::System with system styling" do


### PR DESCRIPTION
## Summary
- Add visual error indication for result steps when `is_error: true`
- Results with errors now display with red styling and ❌ icon
- Success results continue to show with green styling and ✅ icon

## Changes
- Added `error?` method to `Step::Result` model
- Created `step-result` CSS component following RSCSS methodology
- Updated result view template to use dynamic styling based on error state
- Added comprehensive test coverage for both success and error cases

🤖 Generated with [Claude Code](https://claude.ai/code)