### PR TITLE
Fix test URL helper to use shallow route

### DIFF
--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -105,7 +105,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     run = @task.runs.create!(prompt: "test")
     run.steps.create!(type: "Step::Result", content: "API Error occurred", raw_response: '{"type":"result","is_error":true}')
 
-    get project_task_url(@project, @task)
+    get task_url(@task)
     assert_response :success
     assert_select "div.step-result.-error"
     assert_select "div.label", text: "❌ Result (Error)"


### PR DESCRIPTION
## Summary

- Fix TasksControllerTest to use correct URL helper for shallow routes
- Update `project_task_url(@project, @task)` to `task_url(@task)` since tasks use shallow routes

🤖 Generated with [Claude Code](https://claude.ai/code)