### PR TITLE
Add project cookie persistence to dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,8 @@ class DashboardController < ApplicationController
   def index
     @tasks = Task.kept.includes(:agent, :project).order(created_at: :desc)
     @task = Task.new
+    @task.agent_id = cookies[:preferred_agent_id] if cookies[:preferred_agent_id].present?
+    @task.project_id = cookies[:preferred_project_id] if cookies[:preferred_project_id].present?
     @projects = Project.kept
     @agents = Agent.kept
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,6 +18,7 @@ class TasksController < ApplicationController
   def new
     @task = @project.tasks.new
     @task.agent_id = cookies[:preferred_agent_id] if cookies[:preferred_agent_id].present?
+    @task.project_id = cookies[:preferred_project_id] if cookies[:preferred_project_id].present?
   end
 
   def create
@@ -25,6 +26,7 @@ class TasksController < ApplicationController
 
     if @task.save
       cookies[:preferred_agent_id] = { value: @task.agent_id, expires: 1.year.from_now }
+      cookies[:preferred_project_id] = { value: @task.project_id, expires: 1.year.from_now }
       @task.update!(started_at: Time.current)
       @task.run(params[:task][:prompt])
       redirect_to task_path(@task), notice: "Task was successfully launched."


### PR DESCRIPTION
## Summary
- Add project selection cookie persistence to dashboard matching existing agent cookie functionality
- Dashboard pre-selects project from `preferred_project_id` cookie when creating new tasks
- Task creation saves selected project to cookie with 1 year expiration

🤖 Generated with [Claude Code](https://claude.ai/code)