### PR TITLE
Add diff view enhancements with side-by-side toggle and file viewing

### DIFF
--- a/app/assets/stylesheets/diff-controls.css
+++ b/app/assets/stylesheets/diff-controls.css
@@ -1,0 +1,38 @@
+.diff-controls {
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  background-color: var(--surface-secondary);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+@media (prefers-color-scheme: dark) {
+  .diff-controls {
+    background-color: #2d2d2d;
+    border-color: #404040;
+  }
+}
+
+.diff-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: var(--text);
+}
+
+@media (prefers-color-scheme: dark) {
+  .diff-toggle {
+    color: #e6e6e6;
+  }
+}
+
+.diff-toggle input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.diff-toggle-label {
+  cursor: pointer;
+  user-select: none;
+}

--- a/app/assets/stylesheets/run-spinner.css
+++ b/app/assets/stylesheets/run-spinner.css
@@ -10,6 +10,13 @@
   color: #666;
 }
 
+@media (prefers-color-scheme: dark) {
+  .run-spinner {
+    background: #2d2d2d;
+    color: #e6e6e6;
+  }
+}
+
 .run-spinner > .spinner {
   width: 20px;
   height: 20px;
@@ -17,6 +24,13 @@
   border-top: 2px solid #3498db;
   border-radius: 50%;
   animation: spin 1s linear infinite;
+}
+
+@media (prefers-color-scheme: dark) {
+  .run-spinner > .spinner {
+    border: 2px solid #404040;
+    border-top: 2px solid #64b5f6;
+  }
 }
 
 @keyframes spin {

--- a/app/assets/stylesheets/step-init.css
+++ b/app/assets/stylesheets/step-init.css
@@ -6,6 +6,14 @@
   font-size: 0.9em;
 }
 
+@media (prefers-color-scheme: dark) {
+  .step-init {
+    background: #0f2a3f;
+    border-left: 3px solid #4da6d9;
+    color: #e6e6e6;
+  }
+}
+
 .step-init > .label {
   display: block;
 }

--- a/app/assets/stylesheets/step-result.css
+++ b/app/assets/stylesheets/step-result.css
@@ -5,9 +5,24 @@
   border-left: 3px solid #28a745;
 }
 
+@media (prefers-color-scheme: dark) {
+  .step-result {
+    background: #1e4d1e;
+    border-left: 3px solid #4caf50;
+    color: #e6e6e6;
+  }
+}
+
 .step-result.-error {
   background: #f8d7da;
   border-left-color: #dc3545;
+}
+
+@media (prefers-color-scheme: dark) {
+  .step-result.-error {
+    background: #4d1e1e;
+    border-left-color: #f44336;
+  }
 }
 
 .step-result > .label {

--- a/app/assets/stylesheets/system-step.css
+++ b/app/assets/stylesheets/system-step.css
@@ -6,6 +6,14 @@
   font-size: 0.9em;
 }
 
+@media (prefers-color-scheme: dark) {
+  .system-step {
+    background: #2d2d2d;
+    border-left: 3px solid #bbb;
+    color: #e6e6e6;
+  }
+}
+
 .system-step > .label {
   display: block;
   margin-bottom: 5px;

--- a/app/assets/stylesheets/tabs-container.css
+++ b/app/assets/stylesheets/tabs-container.css
@@ -10,6 +10,12 @@
   border-bottom: 1px solid #ccc;
 }
 
+@media (prefers-color-scheme: dark) {
+  .tabs-container > .nav {
+    border-bottom: 1px solid #404040;
+  }
+}
+
 .tabs-container > .nav > .tab {
   padding: 10px 20px;
   background: #d8d8d8;
@@ -25,9 +31,24 @@
   margin-bottom: -1px;
 }
 
+@media (prefers-color-scheme: dark) {
+  .tabs-container > .nav > .tab {
+    background: #2d2d2d;
+    border: 1px solid #404040;
+    color: #b3b3b3;
+  }
+}
+
 .tabs-container > .nav > .tab:hover {
   background: #e0e0e0;
   color: #333;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tabs-container > .nav > .tab:hover {
+    background: #404040;
+    color: #e6e6e6;
+  }
 }
 
 .tabs-container > .nav > .tab.-active {
@@ -39,12 +60,26 @@
   padding-bottom: 11px;
 }
 
+@media (prefers-color-scheme: dark) {
+  .tabs-container > .nav > .tab.-active {
+    background: #1a1a1a;
+    color: #e6e6e6;
+  }
+}
+
 .tabs-container > .content {
   border: 1px solid #ccc;
   background: #f0f0f0;
   padding: 0;
   position: relative;
   border-top: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tabs-container > .content {
+    border: 1px solid #404040;
+    background: #1a1a1a;
+  }
 }
 
 .tabs-container > .content > .panel {
@@ -60,4 +95,10 @@
   padding: 15px;
   overflow: auto;
   min-height: 200px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tabs-container > .content > .panel > .output {
+    background: #1a1a1a;
+  }
 }

--- a/app/assets/stylesheets/tool-call.css
+++ b/app/assets/stylesheets/tool-call.css
@@ -5,6 +5,14 @@
   border-left: 3px solid #ffc107;
 }
 
+@media (prefers-color-scheme: dark) {
+  .tool-call {
+    background: #3d3411;
+    border-left: 3px solid #d4a017;
+    color: #e6e6e6;
+  }
+}
+
 .tool-call > .label {
   display: block;
   margin-bottom: 5px;

--- a/app/assets/stylesheets/tool-result.css
+++ b/app/assets/stylesheets/tool-result.css
@@ -5,6 +5,14 @@
   border-left: 3px solid #6c757d;
 }
 
+@media (prefers-color-scheme: dark) {
+  .tool-result {
+    background: #2d2d2d;
+    border-left: 3px solid #999;
+    color: #e6e6e6;
+  }
+}
+
 .tool-result > .label {
   display: block;
   margin-bottom: 5px;

--- a/app/javascript/controllers/diff_controller.js
+++ b/app/javascript/controllers/diff_controller.js
@@ -1,12 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["output"]
+  static targets = ["output", "viewToggle"]
   static values = {
     diffText: String
   }
 
   connect() {
+    this.outputFormat = 'side-by-side'
     if (this.hasDiffTextValue && this.diffTextValue.trim()) {
       this.render()
     }
@@ -16,6 +17,11 @@ export default class extends Controller {
     if (this.diffTextValue.trim()) {
       this.render()
     }
+  }
+
+  toggleView() {
+    this.outputFormat = this.viewToggleTarget.checked ? 'side-by-side' : 'line-by-line'
+    this.render()
   }
 
   render() {
@@ -40,14 +46,17 @@ export default class extends Controller {
 
     // Create Diff2HtmlUI instance targeting the shadow DOM container
     const diff2htmlUi = new Diff2HtmlUI(contentContainer, this.diffTextValue, {
-      drawFileList: false,
-      fileListToggle: false,
+      drawFileList: true,
+      fileListToggle: true,
       fileListStartVisible: false,
-      fileContentToggle: false,
+      fileContentToggle: true,
       matching: 'lines',
-      outputFormat: 'line-by-line',
+      outputFormat: this.outputFormat,
       synchronisedScroll: true,
-      renderNothingWhenEmpty: false
+      renderNothingWhenEmpty: false,
+      highlight: true,
+      fileListCloseable: false,
+      colorScheme: 'auto'
     })
     
     diff2htmlUi.draw()

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -143,7 +143,7 @@ class Run < ApplicationRecord
     git_container = Docker::Container.create(
       "Image" => task.agent.docker_image,
       "Entrypoint" => [ "sh" ],
-      "Cmd" => [ "-c", "git add -N . && git diff HEAD" ],
+      "Cmd" => [ "-c", "git add -N . && git diff HEAD --unified=10" ],
       "WorkingDir" => git_working_dir,
       "User" => task.agent.user_id.to_s,
       "HostConfig" => {

--- a/app/views/runs/_diff_panel.html.erb
+++ b/app/views/runs/_diff_panel.html.erb
@@ -1,4 +1,10 @@
 <div data-controller="diff" data-diff-diff-text-value="<%= repo_state.uncommitted_diff.gsub('"', '&quot;') %>">
+  <div class="diff-controls">
+    <label class="diff-toggle">
+      <input type="checkbox" data-action="change->diff#toggleView" data-diff-target="viewToggle" checked>
+      <span class="diff-toggle-label">Side by Side</span>
+    </label>
+  </div>
   <div data-diff-target="output">
     <template shadowrootmode="open">
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css">

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -618,7 +618,7 @@ class RunTest < ActiveSupport::TestCase
     git_diff_container.expects(:delete).with(force: true)
 
     Docker::Container.expects(:create).with do |params|
-      params["Entrypoint"] == [ "sh" ] && params["Cmd"] == [ "-c", "git add -N . && git diff HEAD" ] && params["User"] == "1000"
+      params["Entrypoint"] == [ "sh" ] && params["Cmd"] == [ "-c", "git add -N . && git diff HEAD --unified=10" ] && params["User"] == "1000"
     end.returns(git_diff_container)
   end
 end


### PR DESCRIPTION
## Summary
- Add checkbox toggle for switching between side-by-side and unified diff views
- Enable diff2html file list with mark-as-viewed functionality for better diff review
- Increase diff context lines from 3 to 10 lines for better code visibility
- Add comprehensive dark mode support that matches diff2html's color scheme
- Update all step types for proper contrast in dark mode

🤖 Generated with [Claude Code](https://claude.ai/code)