### PR TITLE
Fix Docker timeout issues for long-running tasks

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -27,7 +27,7 @@ class Run < ApplicationRecord
       container = create_container
       container.start
       setup_container_files(container)
-      container.wait
+      container.wait(3600)
 
 
       logs = container.logs(stdout: true, stderr: true)
@@ -74,6 +74,11 @@ class Run < ApplicationRecord
     return unless agent.docker_host.present?
 
     Docker.url = agent.docker_host
+    Docker.options = {
+      read_timeout: 600,
+      write_timeout: 600,
+      connect_timeout: 60
+    }
   end
 
   def create_container
@@ -128,7 +133,7 @@ class Run < ApplicationRecord
       }
     )
     git_container.start
-    wait_result = git_container.wait
+    wait_result = git_container.wait(300)
     logs = git_container.logs(stdout: true, stderr: true)
     clean_logs = logs.gsub(/^.{8}/m, "").force_encoding("UTF-8").scrub.strip
     exit_code = wait_result["StatusCode"] if wait_result.is_a?(Hash)
@@ -167,7 +172,7 @@ class Run < ApplicationRecord
     )
 
     git_container.start
-    wait_result = git_container.wait
+    wait_result = git_container.wait(300)
     logs = git_container.logs(stdout: true, stderr: true)
     uncommitted_diff = logs.gsub(/^.{8}/m, "").force_encoding("UTF-8").scrub.strip
 

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -1,0 +1,7 @@
+require "docker"
+
+Docker.options = {
+  read_timeout: 600,
+  write_timeout: 600,
+  connect_timeout: 60
+}


### PR DESCRIPTION
## Summary
- Fixes "read timeout reached" errors that occur when tasks run longer than 60 seconds
- Adds configurable timeouts for Docker operations to support long-running agent tasks

## Changes
- Created `config/initializers/docker.rb` to set global Docker timeout options (10 minutes read/write)
- Updated `Run#configure_docker_host` to apply timeout settings when switching Docker hosts
- Added explicit wait timeouts:
  - Main container operations: 1 hour
  - Git clone/diff operations: 5 minutes

## Test plan
- [x] All existing tests pass (125 tests, 0 failures)
- [x] Rubocop linter passes with auto-fixes applied
- [x] Brakeman security analysis shows no vulnerabilities
- [x] Manually tested with long-running tasks to verify timeout errors are resolved