### PR TITLE
Add markdown rendering for Step::Text with syntax highlighting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "thruster", require: false
 
 gem "docker-api"
 gem "discard"
+gem "redcarpet"
+gem "rouge"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,10 +310,12 @@ GEM
     rdoc (6.14.0)
       erb
       psych (>= 4.0.0)
+    redcarpet (3.6.1)
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
     rexml (3.4.1)
+    rouge (4.5.2)
     rubocop (1.75.7)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -449,6 +451,8 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  redcarpet
+  rouge
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/assets/stylesheets/rouge-github.css
+++ b/app/assets/stylesheets/rouge-github.css
@@ -1,0 +1,72 @@
+.highlight {
+  background-color: #f6f8fa;
+}
+
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #6a737d } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .k { color: #d73a49 } /* Keyword */
+.highlight .o { color: #d73a49 } /* Operator */
+.highlight .cm { color: #6a737d } /* Comment.Multiline */
+.highlight .cp { color: #6a737d } /* Comment.Preproc */
+.highlight .c1 { color: #6a737d } /* Comment.Single */
+.highlight .cs { color: #6a737d } /* Comment.Special */
+.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight .gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #aa0000 } /* Generic.Error */
+.highlight .gh { color: #999999 } /* Generic.Heading */
+.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight .gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #555555 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #aaaaaa } /* Generic.Subheading */
+.highlight .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight .kc { color: #d73a49 } /* Keyword.Constant */
+.highlight .kd { color: #d73a49 } /* Keyword.Declaration */
+.highlight .kp { color: #d73a49 } /* Keyword.Pseudo */
+.highlight .kr { color: #d73a49 } /* Keyword.Reserved */
+.highlight .kt { color: #d73a49 } /* Keyword.Type */
+.highlight .m { color: #005cc5 } /* Literal.Number */
+.highlight .s { color: #032f62 } /* Literal.String */
+.highlight .na { color: #6f42c1 } /* Name.Attribute */
+.highlight .nb { color: #005cc5 } /* Name.Builtin */
+.highlight .nc { color: #6f42c1 } /* Name.Class */
+.highlight .no { color: #005cc5 } /* Name.Constant */
+.highlight .ni { color: #6f42c1 } /* Name.Entity */
+.highlight .ne { color: #6f42c1 } /* Name.Exception */
+.highlight .nf { color: #6f42c1 } /* Name.Function */
+.highlight .nn { color: #6f42c1 } /* Name.Namespace */
+.highlight .nt { color: #22863a } /* Name.Tag */
+.highlight .nv { color: #e36209 } /* Name.Variable */
+.highlight .ow { color: #d73a49 } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mf { color: #005cc5 } /* Literal.Number.Float */
+.highlight .mh { color: #005cc5 } /* Literal.Number.Hex */
+.highlight .mi { color: #005cc5 } /* Literal.Number.Integer */
+.highlight .mo { color: #005cc5 } /* Literal.Number.Oct */
+.highlight .sb { color: #032f62 } /* Literal.String.Backtick */
+.highlight .sc { color: #032f62 } /* Literal.String.Char */
+.highlight .sd { color: #032f62 } /* Literal.String.Doc */
+.highlight .s2 { color: #032f62 } /* Literal.String.Double */
+.highlight .se { color: #032f62 } /* Literal.String.Escape */
+.highlight .sh { color: #032f62 } /* Literal.String.Heredoc */
+.highlight .si { color: #032f62 } /* Literal.String.Interpol */
+.highlight .sx { color: #032f62 } /* Literal.String.Other */
+.highlight .sr { color: #032f62 } /* Literal.String.Regex */
+.highlight .s1 { color: #032f62 } /* Literal.String.Single */
+.highlight .ss { color: #032f62 } /* Literal.String.Symbol */
+.highlight .bp { color: #005cc5 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #e36209 } /* Name.Variable.Class */
+.highlight .vg { color: #e36209 } /* Name.Variable.Global */
+.highlight .vi { color: #e36209 } /* Name.Variable.Instance */
+.highlight .il { color: #005cc5 } /* Literal.Number.Integer.Long */
+
+.step-text.markdown-content .highlight {
+  background-color: transparent;
+}
+
+.step-text.markdown-content pre.highlight {
+  background-color: var(--color-background-subtle);
+}

--- a/app/assets/stylesheets/step-text.css
+++ b/app/assets/stylesheets/step-text.css
@@ -1,6 +1,153 @@
 .step-text {
   margin: 5px 0;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
+}
+
+.step-text.markdown-content {
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.step-text.markdown-content h1,
+.step-text.markdown-content h2,
+.step-text.markdown-content h3,
+.step-text.markdown-content h4,
+.step-text.markdown-content h5,
+.step-text.markdown-content h6 {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.step-text.markdown-content h1 {
+  font-size: 1.75em;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.3em;
+}
+
+.step-text.markdown-content h2 {
+  font-size: 1.5em;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.3em;
+}
+
+.step-text.markdown-content h3 {
+  font-size: 1.25em;
+}
+
+.step-text.markdown-content h4 {
+  font-size: 1.1em;
+}
+
+.step-text.markdown-content h5 {
+  font-size: 1em;
+}
+
+.step-text.markdown-content h6 {
+  font-size: 0.9em;
+  color: var(--color-text-muted);
+}
+
+.step-text.markdown-content p {
+  margin-bottom: 1em;
+}
+
+.step-text.markdown-content ul,
+.step-text.markdown-content ol {
+  margin-bottom: 1em;
+  padding-left: 2em;
+}
+
+.step-text.markdown-content li {
+  margin-bottom: 0.25em;
+}
+
+.step-text.markdown-content blockquote {
+  margin: 1em 0;
+  padding: 0.5em 1em;
+  border-left: 4px solid var(--color-primary);
+  background-color: var(--color-background-subtle);
+  color: var(--color-text-muted);
+}
+
+.step-text.markdown-content code {
+  padding: 0.2em 0.4em;
+  font-family: monospace;
+  font-size: 0.9em;
+  background-color: var(--color-background-subtle);
+  border-radius: 3px;
+}
+
+.step-text.markdown-content pre {
+  margin: 1em 0;
+  padding: 1em;
+  background-color: var(--color-background-subtle);
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.step-text.markdown-content pre code {
+  background-color: transparent;
+  padding: 0;
+  font-size: 0.9em;
+  line-height: 1.45;
+}
+
+.step-text.markdown-content table {
+  margin: 1em 0;
+  border-collapse: collapse;
+  width: 100%;
+  overflow: auto;
+}
+
+.step-text.markdown-content table th,
+.step-text.markdown-content table td {
+  padding: 0.5em 1em;
+  border: 1px solid var(--color-border);
+}
+
+.step-text.markdown-content table th {
+  background-color: var(--color-background-subtle);
+  font-weight: 600;
+}
+
+.step-text.markdown-content table tr:nth-child(even) {
+  background-color: var(--color-background-subtle);
+}
+
+.step-text.markdown-content hr {
+  margin: 2em 0;
+  border: none;
+  border-top: 1px solid var(--color-border);
+}
+
+.step-text.markdown-content a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.step-text.markdown-content a:hover {
+  text-decoration: underline;
+}
+
+.step-text.markdown-content img {
+  max-width: 100%;
+  height: auto;
+}
+
+.step-text.markdown-content strong {
+  font-weight: 600;
+}
+
+.step-text.markdown-content em {
+  font-style: italic;
+}
+
+.step-text.markdown-content del {
+  text-decoration: line-through;
+}
+
+.step-text.markdown-content mark {
+  background-color: #fff3cd;
+  padding: 0.2em;
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -3,4 +3,9 @@
   --color-danger-hover: #c82333;
   --color-white: white;
   --spacing-sm: 10px;
+  --color-text: #333;
+  --color-text-muted: #666;
+  --color-primary: #007bff;
+  --color-border: #e1e4e8;
+  --color-background-subtle: #f6f8fa;
 }

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,33 @@
+require "rouge/plugins/redcarpet"
+
+module MarkdownHelper
+  class RougeRenderer < Redcarpet::Render::HTML
+    include Rouge::Plugins::Redcarpet
+  end
+
+  def render_markdown(text)
+    return "" if text.blank?
+
+    renderer = RougeRenderer.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { target: "_blank", rel: "noopener noreferrer" }
+    )
+
+    markdown = Redcarpet::Markdown.new(renderer,
+      autolink: true,
+      tables: true,
+      fenced_code_blocks: true,
+      strikethrough: true,
+      lax_html_blocks: true,
+      space_after_headers: true,
+      superscript: true,
+      underline: true,
+      highlight: true,
+      quote: true,
+      footnotes: true
+    )
+
+    markdown.render(text).html_safe
+  end
+end

--- a/app/views/step/texts/_text.html.erb
+++ b/app/views/step/texts/_text.html.erb
@@ -1,1 +1,3 @@
-<pre class="step-text"><%= text.content %></pre>
+<div class="step-text markdown-content">
+  <%= render_markdown(text.content) %>
+</div>

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -53,7 +53,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
     get task_url(@task)
     assert_response :success
-    assert_select "pre", text: "Hello world"
+    assert_select "div.step-text.markdown-content p", text: "Hello world"
   end
 
   test "show renders Step::Init with session initialized message" do

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class MarkdownHelperTest < ActionView::TestCase
+  include MarkdownHelper
+
+  test "renders basic markdown" do
+    markdown = "# Heading\n\nThis is a **bold** text and this is *italic*."
+    result = render_markdown(markdown)
+
+    assert_includes result, "<h1>Heading</h1>"
+    assert_includes result, "<strong>bold</strong>"
+    assert_includes result, "<em>italic</em>"
+  end
+
+  test "renders code blocks with syntax highlighting" do
+    markdown = "```ruby\ndef hello\n  puts 'world'\nend\n```"
+    result = render_markdown(markdown)
+
+    assert_includes result, '<div class="highlight">'
+    assert_includes result, "hello"
+    assert_includes result, "world"
+  end
+
+  test "renders links with security attributes" do
+    markdown = "[Example](https://example.com)"
+    result = render_markdown(markdown)
+
+    assert_includes result, 'target="_blank"'
+    assert_includes result, 'rel="noopener noreferrer"'
+    assert_includes result, "https://example.com"
+  end
+
+  test "renders tables" do
+    markdown = "| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |"
+    result = render_markdown(markdown)
+
+    assert_includes result, "<table>"
+    assert_includes result, "<th>Header 1</th>"
+    assert_includes result, "<td>Cell 1</td>"
+  end
+
+  test "handles empty or nil content" do
+    assert_equal "", render_markdown(nil)
+    assert_equal "", render_markdown("")
+    assert_equal "", render_markdown("   ")
+  end
+
+  test "filters HTML for security" do
+    markdown = "<script>alert('xss')</script>\n\nSafe content"
+    result = render_markdown(markdown)
+
+    refute_includes result, "<script>"
+    assert_includes result, "Safe content"
+  end
+end

--- a/test/models/step/text_test.rb
+++ b/test/models/step/text_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Step::TextTest < ActiveSupport::TestCase
+  test "stores and retrieves content" do
+    run = runs(:one)
+    step = Step::Text.create!(
+      run: run,
+      raw_response: '{"type": "text", "content": "# Hello World"}',
+      content: "# Hello World"
+    )
+
+    assert_equal "# Hello World", step.content
+  end
+
+  test "inherits filtering from Step base class" do
+    user = users(:one)
+    user.update!(github_token: "ghp_secret123")
+    task = tasks(:one)
+    task.update!(user: user)
+    run = runs(:one)
+    run.update!(task: task)
+
+    step = Step::Text.create!(
+      run: run,
+      raw_response: '{"type": "text", "content": "Token: ghp_secret123"}',
+      content: "Token: ghp_secret123"
+    )
+
+    assert_equal "Token: [FILTERED]", step.content
+  end
+end


### PR DESCRIPTION
## Summary
- Enhanced Step::Text display to render markdown with proper formatting and syntax highlighting
- Added secure markdown parsing with XSS protection

## Changes
- Added `redcarpet` and `rouge` gems for markdown parsing and syntax highlighting
- Created `MarkdownHelper` module with secure markdown rendering configuration
- Updated Step::Text view to render markdown instead of plain text
- Added comprehensive CSS styling for all markdown elements (headers, lists, tables, code blocks, etc.)
- Integrated Rouge syntax highlighting with GitHub-inspired theme
- Added CSS variables for consistent theming
- Added comprehensive tests for markdown rendering
- Updated existing controller test to match new HTML structure

## Test plan
- [x] All tests pass (`bin/rails t`)
- [x] Rubocop linting passes (`bundle exec rubocop -A`)
- [x] Security analysis passes (`bin/brakeman --no-pager`)
- [ ] Manual testing: Create Step::Text with various markdown content
- [ ] Verify syntax highlighting works for code blocks
- [ ] Verify XSS protection filters malicious HTML

🤖 Generated with [Claude Code](https://claude.ai/code)