### PR TITLE
Add markdown rendering support to Step::Text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "thruster", require: false
 
 gem "docker-api"
 gem "discard"
+gem "redcarpet"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,7 @@ GEM
     rdoc (6.14.0)
       erb
       psych (>= 4.0.0)
+    redcarpet (3.6.1)
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -449,6 +450,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  redcarpet
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/assets/stylesheets/step-text.css
+++ b/app/assets/stylesheets/step-text.css
@@ -4,3 +4,104 @@
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
+
+.step-text.markdown {
+  white-space: normal;
+}
+
+.step-text.markdown h1,
+.step-text.markdown h2,
+.step-text.markdown h3,
+.step-text.markdown h4,
+.step-text.markdown h5,
+.step-text.markdown h6 {
+  margin: 16px 0 8px 0;
+  font-weight: bold;
+  line-height: 1.25;
+}
+
+.step-text.markdown h1 { font-size: 1.5em; }
+.step-text.markdown h2 { font-size: 1.3em; }
+.step-text.markdown h3 { font-size: 1.1em; }
+.step-text.markdown h4 { font-size: 1em; }
+.step-text.markdown h5 { font-size: 0.9em; }
+.step-text.markdown h6 { font-size: 0.8em; }
+
+.step-text.markdown p {
+  margin: 8px 0;
+}
+
+.step-text.markdown ul,
+.step-text.markdown ol {
+  margin: 8px 0;
+  padding-left: 20px;
+}
+
+.step-text.markdown li {
+  margin: 4px 0;
+}
+
+.step-text.markdown blockquote {
+  margin: 8px 0;
+  padding: 8px 12px;
+  border-left: 3px solid #ddd;
+  background: #f9f9f9;
+}
+
+.step-text.markdown code {
+  background: #f5f5f5;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+.step-text.markdown pre {
+  background: #f5f5f5;
+  padding: 12px;
+  border-radius: 5px;
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+.step-text.markdown pre code {
+  background: none;
+  padding: 0;
+}
+
+.step-text.markdown a {
+  color: #0066cc;
+  text-decoration: underline;
+}
+
+.step-text.markdown a:hover {
+  color: #004499;
+}
+
+.step-text.markdown table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  width: 100%;
+}
+
+.step-text.markdown th,
+.step-text.markdown td {
+  border: 1px solid #ddd;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.step-text.markdown th {
+  background: #f5f5f5;
+  font-weight: bold;
+}
+
+.step-text.markdown del {
+  text-decoration: line-through;
+  color: #666;
+}
+
+.step-text.markdown mark {
+  background: #ffff99;
+  padding: 1px 2px;
+}

--- a/app/assets/stylesheets/step-text.css
+++ b/app/assets/stylesheets/step-text.css
@@ -1,54 +1,50 @@
 .step-text {
   margin: 5px 0;
-  white-space: pre-wrap;
+  white-space: normal;
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
 
-.step-text.markdown {
-  white-space: normal;
-}
-
-.step-text.markdown h1,
-.step-text.markdown h2,
-.step-text.markdown h3,
-.step-text.markdown h4,
-.step-text.markdown h5,
-.step-text.markdown h6 {
+.step-text h1,
+.step-text h2,
+.step-text h3,
+.step-text h4,
+.step-text h5,
+.step-text h6 {
   margin: 16px 0 8px 0;
   font-weight: bold;
   line-height: 1.25;
 }
 
-.step-text.markdown h1 { font-size: 1.5em; }
-.step-text.markdown h2 { font-size: 1.3em; }
-.step-text.markdown h3 { font-size: 1.1em; }
-.step-text.markdown h4 { font-size: 1em; }
-.step-text.markdown h5 { font-size: 0.9em; }
-.step-text.markdown h6 { font-size: 0.8em; }
+.step-text h1 { font-size: 1.5em; }
+.step-text h2 { font-size: 1.3em; }
+.step-text h3 { font-size: 1.1em; }
+.step-text h4 { font-size: 1em; }
+.step-text h5 { font-size: 0.9em; }
+.step-text h6 { font-size: 0.8em; }
 
-.step-text.markdown p {
+.step-text p {
   margin: 8px 0;
 }
 
-.step-text.markdown ul,
-.step-text.markdown ol {
+.step-text ul,
+.step-text ol {
   margin: 8px 0;
   padding-left: 20px;
 }
 
-.step-text.markdown li {
+.step-text li {
   margin: 4px 0;
 }
 
-.step-text.markdown blockquote {
+.step-text blockquote {
   margin: 8px 0;
   padding: 8px 12px;
   border-left: 3px solid #ddd;
   background: #f9f9f9;
 }
 
-.step-text.markdown code {
+.step-text code {
   background: #f5f5f5;
   padding: 2px 4px;
   border-radius: 3px;
@@ -56,7 +52,7 @@
   font-size: 0.9em;
 }
 
-.step-text.markdown pre {
+.step-text pre {
   background: #f5f5f5;
   padding: 12px;
   border-radius: 5px;
@@ -64,44 +60,44 @@
   margin: 8px 0;
 }
 
-.step-text.markdown pre code {
+.step-text pre code {
   background: none;
   padding: 0;
 }
 
-.step-text.markdown a {
+.step-text a {
   color: #0066cc;
   text-decoration: underline;
 }
 
-.step-text.markdown a:hover {
+.step-text a:hover {
   color: #004499;
 }
 
-.step-text.markdown table {
+.step-text table {
   border-collapse: collapse;
   margin: 8px 0;
   width: 100%;
 }
 
-.step-text.markdown th,
-.step-text.markdown td {
+.step-text th,
+.step-text td {
   border: 1px solid #ddd;
   padding: 6px 8px;
   text-align: left;
 }
 
-.step-text.markdown th {
+.step-text th {
   background: #f5f5f5;
   font-weight: bold;
 }
 
-.step-text.markdown del {
+.step-text del {
   text-decoration: line-through;
   color: #666;
 }
 
-.step-text.markdown mark {
+.step-text mark {
   background: #ffff99;
   padding: 1px 2px;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,4 +40,31 @@ module ApplicationHelper
       nil
     end
   end
+
+  def markdown(text)
+    return "" if text.blank?
+
+    options = {
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: "nofollow", target: "_blank" },
+      space_after_headers: true
+    }
+
+    extensions = {
+      autolink: true,
+      superscript: true,
+      disable_indented_code_blocks: true,
+      fenced_code_blocks: true,
+      strikethrough: true,
+      tables: true,
+      underline: true,
+      highlight: true
+    }
+
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown_processor = Redcarpet::Markdown.new(renderer, extensions)
+
+    markdown_processor.render(text).html_safe
+  end
 end

--- a/app/views/step/texts/_text.html.erb
+++ b/app/views/step/texts/_text.html.erb
@@ -1,3 +1,3 @@
-<div class="step-text markdown">
+<div class="step-text">
   <%= markdown(text.content) %>
 </div>

--- a/app/views/step/texts/_text.html.erb
+++ b/app/views/step/texts/_text.html.erb
@@ -1,1 +1,3 @@
-<pre class="step-text"><%= text.content %></pre>
+<div class="step-text markdown">
+  <%= markdown(text.content) %>
+</div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.string "instructions_mount_path"
     t.string "ssh_mount_path"
     t.string "home_path"
-    t.index ["discarded_at"], name: "index_agents_on_discarded_at"
+    t.index [ "discarded_at" ], name: "index_agents_on_discarded_at"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -39,7 +39,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
     t.string "repo_path"
-    t.index ["discarded_at"], name: "index_projects_on_discarded_at"
+    t.index [ "discarded_at" ], name: "index_projects_on_discarded_at"
   end
 
   create_table "repo_states", force: :cascade do |t|
@@ -49,7 +49,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.integer "step_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["step_id"], name: "index_repo_states_on_step_id"
+    t.index [ "step_id" ], name: "index_repo_states_on_step_id"
   end
 
   create_table "runs", force: :cascade do |t|
@@ -60,7 +60,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["task_id"], name: "index_runs_on_task_id"
+    t.index [ "task_id" ], name: "index_runs_on_task_id"
   end
 
   create_table "secrets", force: :cascade do |t|
@@ -69,8 +69,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["project_id", "key"], name: "index_secrets_on_project_id_and_key", unique: true
-    t.index ["project_id"], name: "index_secrets_on_project_id"
+    t.index [ "project_id", "key" ], name: "index_secrets_on_project_id_and_key", unique: true
+    t.index [ "project_id" ], name: "index_secrets_on_project_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -79,7 +79,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.string "user_agent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_sessions_on_user_id"
+    t.index [ "user_id" ], name: "index_sessions_on_user_id"
   end
 
   create_table "steps", force: :cascade do |t|
@@ -89,8 +89,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.datetime "updated_at", null: false
     t.string "type"
     t.text "content"
-    t.index ["run_id"], name: "index_steps_on_run_id"
-    t.index ["type"], name: "index_steps_on_type"
+    t.index [ "run_id" ], name: "index_steps_on_run_id"
+    t.index [ "type" ], name: "index_steps_on_type"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -103,10 +103,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
     t.integer "user_id", null: false
-    t.index ["agent_id"], name: "index_tasks_on_agent_id"
-    t.index ["discarded_at"], name: "index_tasks_on_discarded_at"
-    t.index ["project_id"], name: "index_tasks_on_project_id"
-    t.index ["user_id"], name: "index_tasks_on_user_id"
+    t.index [ "agent_id" ], name: "index_tasks_on_agent_id"
+    t.index [ "discarded_at" ], name: "index_tasks_on_discarded_at"
+    t.index [ "project_id" ], name: "index_tasks_on_project_id"
+    t.index [ "user_id" ], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -119,7 +119,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.text "instructions"
     t.text "ssh_key"
     t.text "git_config"
-    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
   end
 
   create_table "volume_mounts", force: :cascade do |t|
@@ -128,8 +128,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "volume_name"
-    t.index ["task_id"], name: "index_volume_mounts_on_task_id"
-    t.index ["volume_id"], name: "index_volume_mounts_on_volume_id"
+    t.index [ "task_id" ], name: "index_volume_mounts_on_task_id"
+    t.index [ "volume_id" ], name: "index_volume_mounts_on_volume_id"
   end
 
   create_table "volumes", force: :cascade do |t|
@@ -138,7 +138,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_034140) do
     t.integer "agent_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["agent_id"], name: "index_volumes_on_agent_id"
+    t.index [ "agent_id" ], name: "index_volumes_on_agent_id"
   end
 
   add_foreign_key "repo_states", "steps"

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -53,7 +53,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
     get task_url(@task)
     assert_response :success
-    assert_select "div.step-text.markdown p", text: "Hello world"
+    assert_select "div.step-text p", text: "Hello world"
   end
 
   test "show renders Step::Text with markdown formatting" do
@@ -64,10 +64,10 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
     get task_url(@task)
     assert_response :success
-    assert_select "div.step-text.markdown"
-    assert_select "div.step-text.markdown h1", text: "Header"
-    assert_select "div.step-text.markdown strong", text: "bold"
-    assert_select "div.step-text.markdown code", text: "code"
+    assert_select "div.step-text"
+    assert_select "div.step-text h1", text: "Header"
+    assert_select "div.step-text strong", text: "bold"
+    assert_select "div.step-text code", text: "code"
   end
 
   test "show renders Step::Init with session initialized message" do

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -53,7 +53,21 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
     get task_url(@task)
     assert_response :success
-    assert_select "pre", text: "Hello world"
+    assert_select "div.step-text.markdown p", text: "Hello world"
+  end
+
+  test "show renders Step::Text with markdown formatting" do
+    login @user
+    run = @task.runs.create!(prompt: "test")
+    markdown_content = "# Header\n\nSome **bold** text and `code`"
+    run.steps.create!(type: "Step::Text", content: markdown_content, raw_response: "raw data")
+
+    get task_url(@task)
+    assert_response :success
+    assert_select "div.step-text.markdown"
+    assert_select "div.step-text.markdown h1", text: "Header"
+    assert_select "div.step-text.markdown strong", text: "bold"
+    assert_select "div.step-text.markdown code", text: "code"
   end
 
   test "show renders Step::Init with session initialized message" do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "markdown renders basic text as paragraph" do
+    result = markdown("Hello world")
+    assert_includes result, "<p>Hello world</p>"
+  end
+
+  test "markdown renders headers correctly" do
+    result = markdown("# Header 1\n## Header 2")
+    assert_includes result, "<h1>Header 1</h1>"
+    assert_includes result, "<h2>Header 2</h2>"
+  end
+
+  test "markdown renders code blocks" do
+    result = markdown("```\nrequire 'test'\n```")
+    assert_includes result, "<pre><code>"
+    assert_includes result, "require &#39;test&#39;"
+  end
+
+  test "markdown renders inline code" do
+    result = markdown("Use `code` here")
+    assert_includes result, "<code>code</code>"
+  end
+
+  test "markdown renders lists" do
+    result = markdown("- Item 1\n- Item 2")
+    assert_includes result, "<ul>"
+    assert_includes result, "<li>Item 1</li>"
+    assert_includes result, "<li>Item 2</li>"
+  end
+
+  test "markdown renders links with security attributes" do
+    result = markdown("[Link](https://example.com)")
+    assert_includes result, 'rel="nofollow"'
+    assert_includes result, 'target="_blank"'
+  end
+
+  test "markdown handles empty text" do
+    assert_equal "", markdown("")
+    assert_equal "", markdown(nil)
+  end
+
+  test "markdown filters HTML for security" do
+    result = markdown("<script>alert('xss')</script>")
+    refute_includes result, "<script>"
+  end
+
+  test "markdown renders strikethrough" do
+    result = markdown("~~strikethrough text~~")
+    assert_includes result, "<del>strikethrough text</del>"
+  end
+
+  test "markdown renders tables" do
+    table_markdown = "| Col 1 | Col 2 |\n|-------|-------|\n| A | B |"
+    result = markdown(table_markdown)
+    assert_includes result, "<table>"
+    assert_includes result, "<th>Col 1</th>"
+    assert_includes result, "<td>A</td>"
+  end
+end


### PR DESCRIPTION
## Summary
- Add comprehensive markdown rendering to Step::Text components
- Replace plain text display with rich formatted markdown content

## Changes
- ✨ Add redcarpet gem for robust markdown processing
- 🔧 Update Step::Text view template to use markdown helper
- 🎨 Add comprehensive CSS styling for all markdown elements
- 🛡️ Include security features (HTML filtering, safe external links)
- ✅ Add comprehensive test coverage for markdown functionality
- 🔄 Update existing tests to work with new rendering

## Supported Markdown Features
- Headers (H1-H6) with proper sizing
- **Bold** and *italic* text formatting  
- `Inline code` and fenced code blocks
- Unordered and ordered lists
- Tables with borders and styling
- ~~Strikethrough~~ text
- [External links](https://example.com) with security attributes
- > Blockquotes with proper styling

🤖 Generated with [Claude Code](https://claude.ai/code)