### PR TITLE
Add terminal-style display for Bash tool calls

### DIFF
--- a/app/assets/stylesheets/bash-tool.css
+++ b/app/assets/stylesheets/bash-tool.css
@@ -1,0 +1,28 @@
+.bash-tool {
+  background-color: var(--bg-terminal, #1e1e1e);
+  color: var(--text-terminal, #d4d4d4);
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0.5rem 0;
+  overflow-x: auto;
+}
+
+.terminal-prompt {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.prompt-symbol {
+  color: var(--prompt-symbol, #569cd6);
+  font-weight: bold;
+  user-select: none;
+}
+
+.command {
+  color: var(--command-text, #d4d4d4);
+  flex: 1;
+}

--- a/app/models/log_processor/concerns/claude_json_processing.rb
+++ b/app/models/log_processor/concerns/claude_json_processing.rb
@@ -15,7 +15,12 @@ module LogProcessor::Concerns::ClaudeJsonProcessing
       end
     when "assistant"
       if has_tool_use?(item)
-        { raw_response: item_json, type: "Step::ToolCall", content: extract_content(item) }
+        tool_use = item["message"]["content"].find { |c| c["type"] == "tool_use" }
+        if tool_use && tool_use["name"] == "Bash"
+          { raw_response: item_json, type: "Step::BashTool", content: extract_content(item) }
+        else
+          { raw_response: item_json, type: "Step::ToolCall", content: extract_content(item) }
+        end
       else
         { raw_response: item_json, type: "Step::Text", content: extract_content(item) }
       end
@@ -47,7 +52,11 @@ module LogProcessor::Concerns::ClaudeJsonProcessing
         if has_tool_use?(item)
           tool_use = item["message"]["content"].find { |c| c["type"] == "tool_use" }
           if tool_use
-            "name: #{tool_use['name']}\ninputs: #{tool_use['input'].to_json}"
+            if tool_use["name"] == "Bash"
+              tool_use["input"]["command"]
+            else
+              "name: #{tool_use['name']}\ninputs: #{tool_use['input'].to_json}"
+            end
           else
             item.to_json
           end

--- a/app/models/step/bash_tool.rb
+++ b/app/models/step/bash_tool.rb
@@ -1,0 +1,2 @@
+class Step::BashTool < Step
+end

--- a/app/views/step/bash_tools/_bash_tool.html.erb
+++ b/app/views/step/bash_tools/_bash_tool.html.erb
@@ -1,0 +1,6 @@
+<div class="bash-tool">
+  <div class="terminal-prompt">
+    <span class="prompt-symbol">$</span>
+    <span class="command"><%= bash_tool.content %></span>
+  </div>
+</div>

--- a/test/models/log_processor/claude_json_test.rb
+++ b/test/models/log_processor/claude_json_test.rb
@@ -90,4 +90,29 @@ class LogProcessor::ClaudeJsonTest < ActiveSupport::TestCase
     expected_content = "name: WebFetch\ninputs: {\"url\":\"https://example.com\",\"prompt\":\"What is the title?\"}"
     assert_equal expected_content, result[0][:content]
   end
+
+  test "process creates Step::BashTool for Bash tool calls" do
+    processor = LogProcessor::ClaudeJson.new
+    logs = '{
+      "type": "assistant",
+      "message": {
+        "content": [
+          {
+            "type": "tool_use",
+            "name": "Bash",
+            "input": {
+              "command": "ls -la",
+              "description": "List files in current directory"
+            }
+          }
+        ]
+      }
+    }'
+
+    result = processor.process(logs)
+
+    assert_equal 1, result.size
+    assert_equal "Step::BashTool", result[0][:type]
+    assert_equal "ls -la", result[0][:content]
+  end
 end

--- a/test/models/log_processor/claude_streaming_json_test.rb
+++ b/test/models/log_processor/claude_streaming_json_test.rb
@@ -55,6 +55,16 @@ class LogProcessor::ClaudeStreamingJsonTest < ActiveSupport::TestCase
     assert_includes steps[0][:content], "name: bash"
   end
 
+  test "processes Bash tool calls as Step::BashTool" do
+    logs = '{"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls -la", "description": "List files"}}]}}'
+
+    steps = @processor.process(logs)
+
+    assert_equal 1, steps.length
+    assert_equal "Step::BashTool", steps[0][:type]
+    assert_equal "ls -la", steps[0][:content]
+  end
+
   test "processes tool results correctly" do
     logs = '{"type": "user", "message": {"content": [{"content": "file1.txt\nfile2.txt"}]}}'
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Implements specialized rendering for Bash tool calls to appear like terminal commands
- Replaces generic tool call display with clean `$ command` format for better readability
- Adds dedicated Step::BashTool model with custom view and CSS styling

This change improves log readability by displaying Bash commands as they would appear in a terminal, making it easier to follow agent actions.
EOF
)