### PR TITLE
Hide diff tab when no changes exist

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -161,10 +161,13 @@ class Run < ApplicationRecord
       type: "Step::System",
       content: "Repository state captured\n\nUncommitted diff:\n#{uncommitted_diff}"
     )
-    repo_state_step.repo_states.create!(
-      uncommitted_diff: uncommitted_diff,
-      repository_path: git_working_dir
-    )
+
+    if uncommitted_diff.present?
+      repo_state_step.repo_states.create!(
+        uncommitted_diff: uncommitted_diff,
+        repository_path: git_working_dir
+      )
+    end
   rescue => e
     Rails.logger.error "Failed to capture repository state: #{e.message}"
   ensure


### PR DESCRIPTION
## Summary
• Hide diff tab when there are no uncommitted changes to display
• Only create repo_states when actual diff content exists
• Improves UI clarity by removing empty diff tabs

🤖 Generated with [Claude Code](https://claude.ai/code)