### PR TITLE
Add setup script execution feature

### DIFF
--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -4,13 +4,13 @@ one:
   name: MyString
   description: MyText
   repository_url: http://example.com/one.git
-  setup_script: MyText
+  setup_script: ""
 
 two:
   name: MyString
   description: MyText
   repository_url: http://example.com/two.git
-  setup_script: MyText
+  setup_script: ""
 
 without_repo:
   name: Test Project


### PR DESCRIPTION
## Summary
- Added automatic execution of project setup scripts after repository cloning
- Setup scripts run in isolated containers with full access to project environment variables
- Only executes on first run to avoid redundant setup operations

## Implementation Details
- Added `run_setup_script` method to Run model that executes the project's setup script in a separate Docker container
- Modified `execute\!` flow to run setup script after cloning but before main container creation
- Setup script runs with same working directory as cloned repository and includes all project/agent environment variables
- Creates a system step to track setup script execution and output
- Handles setup script failures gracefully with proper error reporting

## Test plan
- [x] Added comprehensive test coverage for setup script execution
- [x] Tests verify setup script runs only on first run
- [x] Tests handle setup script failures appropriately
- [x] Tests confirm environment variables are passed correctly
- [x] All existing tests continue to pass
- [x] Rubocop linting passes
- [x] Brakeman security analysis shows no issues

🤖 Generated with [Claude Code](https://claude.ai/code)