### PR TITLE
Hide auto-push form when GitHub token is not set

### DIFF
--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -28,7 +28,9 @@
 
 <h2>New Run</h2>
 <%= render "run_form", task: @task, run: Run.new %>
-<%= render "tasks/auto_push_form", task: @task %>
+<% if Current.user&.github_token.present? %>
+  <%= render "tasks/auto_push_form", task: @task %>
+<% end %>
 
 <div class="task-actions">
   <%= link_to 'Archive', task_path(@task), 


### PR DESCRIPTION
## Summary
- Conditionally render the auto-push form only when user has a GitHub token
- Prevents showing non-functional UI to users without GitHub integration

## Changes
- Added conditional check in `tasks/show.html.erb`
- Form is now only displayed when `Current.user&.github_token.present?`

This ensures users without a GitHub token won't see a form they can't use.