### PR TITLE
Add automatic GitHub token seeding from GITHUB_TOKEN env variable

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 #   end
 
 if Rails.env.development?
-  User.find_or_create_by!(email_address: "dev@example.com") do |user|
+  dev_user = User.find_or_create_by!(email_address: "dev@example.com") do |user|
     user.password = "password"
     user.password_confirmation = "password"
     user.role = "admin"
@@ -20,7 +20,11 @@ if Rails.env.development?
     CONFIG
   end
 
-  User.find_or_create_by!(email_address: "user@example.com") do |user|
+  if ENV["GITHUB_TOKEN"].present? && dev_user.github_token.blank?
+    dev_user.update!(github_token: ENV["GITHUB_TOKEN"])
+  end
+
+  standard_user = User.find_or_create_by!(email_address: "user@example.com") do |user|
     user.password = "password"
     user.password_confirmation = "password"
     user.role = "standard"
@@ -29,6 +33,10 @@ if Rails.env.development?
         name = Standard User
         email = user@example.com
     CONFIG
+  end
+
+  if ENV["GITHUB_TOKEN"].present? && standard_user.github_token.blank?
+    standard_user.update!(github_token: ENV["GITHUB_TOKEN"])
   end
 
   claude_agent = Agent.find_or_create_by!(name: "Claude") do |agent|


### PR DESCRIPTION
## Summary
- Automatically seeds GitHub tokens from the GITHUB_TOKEN environment variable during database seeding
- Updates both dev@example.com and user@example.com users with the token if present
- Only sets the token if the user doesn't already have one configured

## Implementation Details
The seeds.rb file now:
1. Checks for the presence of GITHUB_TOKEN environment variable
2. Updates existing users with the token only if they don't already have one set
3. Works seamlessly with the existing encrypted github_token field in the User model

This makes it easier to set up development environments with GitHub integration without manually updating user records.

## Testing
- Tested with `GITHUB_TOKEN="test_token" bin/rails db:seed`
- Verified tokens are set correctly for both users
- All tests pass, linter clean, and security analysis shows no issues