### PR TITLE
Configure FastMCP auth token with fallback for Docker builds

### DIFF
--- a/config/initializers/fast_mcp.rb
+++ b/config/initializers/fast_mcp.rb
@@ -26,8 +26,8 @@ FastMcp.mount_in_rails(
   # localhost_only: true, # Set to false to allow connections from other hosts
   # whitelist specific ips to if you want to run on localhost and allow connections from other IPs
   allowed_ips: [ "127.0.0.1", "::1", "172.18.0.1" ],
-  authenticate: false,       # TODO can't use auth until https://github.com/anthropics/claude-code/issues/1763 is fixed
-  # auth_token: Rails.application.credentials.dig(:fast_mcp, :auth_token), # Required if authenticate: true
+  authenticate: Rails.application.credentials.dig(:fast_mcp, :auth_token).present?,
+  auth_token: Rails.application.credentials.dig(:fast_mcp, :auth_token) || "dummy-token-for-precompile"
 ) do |server|
   Rails.application.config.after_initialize do
     # FastMcp will automatically discover and register:


### PR DESCRIPTION
## Summary
- Configure FastMCP to use auth token from Rails credentials when available
- Enable authentication automatically when token is present  
- Add fallback to dummy token when master key unavailable (e.g., Docker builds)
- Ensures asset precompilation works without credentials access

🤖 Generated with [Claude Code](https://claude.ai/code)