### PR TITLE
Implement split chat/log layout

### DIFF
--- a/app/assets/stylesheets/chat-panel.css
+++ b/app/assets/stylesheets/chat-panel.css
@@ -1,0 +1,28 @@
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#chat-messages {
+  flex: 1;
+}
+
+.chat-item {
+  margin-bottom: 10px;
+}
+
+.chat-item > .user-message,
+.chat-item > .assistant-message {
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+
+.chat-item > .user-message {
+  background: #e6f2ff;
+}
+
+.chat-item > .assistant-message {
+  background: #f0f0f0;
+}

--- a/app/assets/stylesheets/codex-layout.css
+++ b/app/assets/stylesheets/codex-layout.css
@@ -1,0 +1,40 @@
+.codex-layout {
+  display: flex;
+  gap: 20px;
+}
+
+.codex-layout > .chat-panel {
+  width: 40%;
+}
+
+.codex-layout > .log-panel {
+  width: 60%;
+}
+
+@media (max-width: 768px) {
+  .codex-layout {
+    flex-direction: column;
+  }
+
+  .codex-layout > .chat-panel {
+    display: none;
+  }
+
+  .chat-tab {
+    display: inline-block;
+  }
+
+  .chat-panel-tab {
+    display: block;
+  }
+}
+
+@media (min-width: 769px) {
+  .chat-tab {
+    display: none;
+  }
+
+  .chat-panel-tab {
+    display: none;
+  }
+}

--- a/app/views/runs/_chat_item.html.erb
+++ b/app/views/runs/_chat_item.html.erb
@@ -1,0 +1,20 @@
+<div class="chat-item">
+  <div class="user-message">
+    <%= markdown(run.prompt) %>
+  </div>
+  <% result_step = run.steps.find { |s| s.is_a?(Step::Result) } %>
+  <% error_step = run.steps.find { |s| s.is_a?(Step::Error) } %>
+  <% if result_step %>
+    <div class="assistant-message">
+      <%= markdown(result_step.content) %>
+    </div>
+  <% elsif error_step %>
+    <div class="assistant-message">
+      <pre><%= error_step.content %></pre>
+    </div>
+  <% elsif run.status == "running" %>
+    <div class="assistant-message">
+      Processing...
+    </div>
+  <% end %>
+</div>

--- a/app/views/runs/_tabs.html.erb
+++ b/app/views/runs/_tabs.html.erb
@@ -1,7 +1,10 @@
 <% repo_states = run.repo_states %>
 <div data-controller="tabs" class="tabs-container">
   <div class="nav">
-    <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="steps" class="tab -active">Steps</button>
+    <% if local_assigns[:show_chat] %>
+      <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="chat" class="tab chat-tab">Chat</button>
+    <% end %>
+    <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="steps" class="tab -active">Log</button>
     <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="raw" class="tab">Raw</button>
     <% repo_states.each_with_index do |repo_state, index| %>
       <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="diff-<%= index %>" class="tab">
@@ -10,6 +13,14 @@
     <% end %>
   </div>
   <div class="content">
+    <% if local_assigns[:show_chat] %>
+      <div data-tabs-target="panel" data-panel-id="chat" class="panel chat-panel-tab">
+        <div class="output">
+          <% chat_runs = run.task.runs.includes(:steps).order(created_at: :asc) %>
+          <%= render "tasks/chat_panel", task: run.task, runs: chat_runs %>
+        </div>
+      </div>
+    <% end %>
     <div data-tabs-target="panel" data-panel-id="steps" class="panel -active">
       <div class="output">
         <%= render run.steps %>

--- a/app/views/tasks/_chat_panel.html.erb
+++ b/app/views/tasks/_chat_panel.html.erb
@@ -1,0 +1,15 @@
+<div class="chat-panel">
+  <% if runs.any? %>
+    <div id="chat-messages">
+      <% runs.each do |run| %>
+        <%= render "runs/chat_item", run: run %>
+      <% end %>
+    </div>
+  <% else %>
+    <p>No conversation yet.</p>
+  <% end %>
+  <%= render "tasks/run_form", task: task, run: Run.new %>
+  <% if Current.user&.github_token.present? %>
+    <%= render "tasks/auto_push_form", task: task %>
+  <% end %>
+</div>

--- a/app/views/tasks/_run.html.erb
+++ b/app/views/tasks/_run.html.erb
@@ -8,13 +8,8 @@
       | <strong>Completed:</strong> <%= run.completed_at.strftime("%Y-%m-%d %H:%M:%S") %>
     <% end %>
   </p>
-  <div class="prompt" data-controller="prompt-truncate" data-prompt-truncate-max-length-value="200">
-    <strong>Prompt:</strong> 
-    <span data-prompt-truncate-target="content"><%= run.prompt %></span>
-    <button data-prompt-truncate-target="toggle" data-action="click->prompt-truncate#toggle" class="prompt-toggle" style="display: none;">Show more</button>
-  </div>
   <% if run.steps.any? %>
-    <%= render "runs/tabs", run: run %>
+    <%= render "runs/tabs", run: run, show_chat: local_assigns[:show_chat] %>
   <% elsif run.status == 'running' %>
     <p class="title">Output:</p>
     <div class="run-spinner">

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -3,37 +3,35 @@
 <p>Agent: <%= @task.agent.name %></p>
 <p>Project: <%= @task.project.name %></p>
 
-<h2>Runs</h2>
-<% if @task.runs.any? %>
-  <% if @task.runs.count > 1 %>
-    <div class="run-filter">
-      <% if @show_all_runs %>
-        <%= link_to "Show Last Run Only", task_path(@task), class: "action-button -primary" %>
-      <% else %>
-        <%= link_to "Show All Runs", task_path(@task, show_all_runs: true), class: "action-button -success" %>
-      <% end %>
-    </div>
-  <% end %>
+<div class="codex-layout">
   <%= turbo_stream_from @task %>
-  <div id="runs-list">
-    <% @runs.each do |run| %>
-      <%= render "tasks/run", run: run %>
+  <%= render "tasks/chat_panel", task: @task, runs: @task.runs.order(:created_at) %>
+  <div class="log-panel">
+    <% if @task.runs.any? %>
+      <% if @task.runs.count > 1 %>
+        <div class="run-filter">
+          <% if @show_all_runs %>
+            <%= link_to "Show Last Run Only", task_path(@task), class: "action-button -primary" %>
+          <% else %>
+            <%= link_to "Show All Runs", task_path(@task, show_all_runs: true), class: "action-button -success" %>
+          <% end %>
+        </div>
+      <% end %>
+      <div id="runs-list">
+        <% @runs.each_with_index do |run, index| %>
+          <%= render "tasks/run", run: run, show_chat: index.zero? %>
+        <% end %>
+      </div>
+    <% else %>
+      <div id="runs-list">
+        <p>No runs yet.</p>
+      </div>
     <% end %>
   </div>
-<% else %>
-  <div id="runs-list">
-    <p>No runs yet.</p>
-  </div>
-<% end %>
-
-<h2>New Run</h2>
-<%= render "run_form", task: @task, run: Run.new %>
-<% if Current.user&.github_token.present? %>
-  <%= render "tasks/auto_push_form", task: @task %>
-<% end %>
+</div>
 
 <div class="task-actions">
-  <%= link_to 'Archive', task_path(@task), 
+  <%= link_to 'Archive', task_path(@task),
               data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this task?' },
               class: 'archive' %> |
   <%= link_to 'Back', project_tasks_path(@task.project) %>

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -173,20 +173,21 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     assert_select "pre", text: "fallback raw data"
   end
 
-  test "show displays only last run by default" do
+  test "show displays all prompts in chat but only last log by default" do
     login @user
-    new_run = @task.runs.create!(prompt: "newest run", created_at: Time.current)
+    @task.runs.create!(prompt: "newest run", created_at: Time.current)
 
     get task_url(@task)
     assert_response :success
 
     assert_includes response.body, "newest run"
-    assert_not_includes response.body, "echo hello"
+    assert_includes response.body, "echo hello"
+    assert_select "#runs-list > div.run-item", count: 1
   end
 
-  test "show displays all runs when show_all_runs parameter is true" do
+  test "show displays all logs when show_all_runs parameter is true" do
     login @user
-    new_run = @task.runs.create!(prompt: "newest run", created_at: Time.current)
+    @task.runs.create!(prompt: "newest run", created_at: Time.current)
 
     get task_url(@task, show_all_runs: true)
     assert_response :success
@@ -194,6 +195,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "newest run"
     assert_includes response.body, "echo hello"
     assert_includes response.body, "echo world"
+    assert_select "#runs-list > div.run-item", minimum: 2
   end
 
   test "show displays correct toggle button text when multiple runs exist" do


### PR DESCRIPTION
## Summary
- add chat item and panel partials
- show chat on left and logs on right
- include chat as tab for small screens
- style new layout
- adjust controller tests for new behaviour

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684d29313258832d8cd6d2d822539244