### PR TITLE
Fix duplicate chat panel

### DIFF
--- a/app/assets/stylesheets/codex-layout.css
+++ b/app/assets/stylesheets/codex-layout.css
@@ -36,4 +36,7 @@
   .chat-tab {
     display: none;
   }
+  .codex-layout > .nav {
+    display: none;
+  }
 }

--- a/app/assets/stylesheets/codex-layout.css
+++ b/app/assets/stylesheets/codex-layout.css
@@ -3,6 +3,7 @@
   gap: 20px;
 }
 
+
 .codex-layout > .chat-panel {
   width: 40%;
 }
@@ -16,25 +17,23 @@
     flex-direction: column;
   }
 
-  .codex-layout > .chat-panel {
+  .codex-layout > .chat-panel,
+  .codex-layout > .log-panel {
     display: none;
+  }
+
+  .codex-layout > .chat-panel.-active,
+  .codex-layout > .log-panel.-active {
+    display: block;
   }
 
   .chat-tab {
     display: inline-block;
   }
-
-  .chat-panel-tab {
-    display: block;
-  }
 }
 
 @media (min-width: 769px) {
   .chat-tab {
-    display: none;
-  }
-
-  .chat-panel-tab {
     display: none;
   }
 }

--- a/app/views/runs/_tabs.html.erb
+++ b/app/views/runs/_tabs.html.erb
@@ -1,9 +1,6 @@
 <% repo_states = run.repo_states %>
 <div data-controller="tabs" class="tabs-container">
   <div class="nav">
-    <% if local_assigns[:show_chat] %>
-      <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="chat" class="tab chat-tab">Chat</button>
-    <% end %>
     <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="steps" class="tab -active">Log</button>
     <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="raw" class="tab">Raw</button>
     <% repo_states.each_with_index do |repo_state, index| %>
@@ -13,14 +10,6 @@
     <% end %>
   </div>
   <div class="content">
-    <% if local_assigns[:show_chat] %>
-      <div data-tabs-target="panel" data-panel-id="chat" class="panel chat-panel-tab">
-        <div class="output">
-          <% chat_runs = run.task.runs.includes(:steps).order(created_at: :asc) %>
-          <%= render "tasks/chat_panel", task: run.task, runs: chat_runs %>
-        </div>
-      </div>
-    <% end %>
     <div data-tabs-target="panel" data-panel-id="steps" class="panel -active">
       <div class="output">
         <%= render run.steps %>

--- a/app/views/tasks/_run.html.erb
+++ b/app/views/tasks/_run.html.erb
@@ -8,5 +8,5 @@
       | <strong>Completed:</strong> <%= run.completed_at.strftime("%Y-%m-%d %H:%M:%S") %>
     <% end %>
   </p>
-  <%= render "runs/tabs", run: run, show_chat: local_assigns[:show_chat] %>
+  <%= render "runs/tabs", run: run %>
 </div>

--- a/app/views/tasks/_runs_list.html.erb
+++ b/app/views/tasks/_runs_list.html.erb
@@ -1,5 +1,5 @@
 <div id="runs-list">
-  <% runs.each_with_index do |run, index| %>
-    <%= render "tasks/run", run: run, show_chat: index.zero? %>
+  <% runs.each do |run| %>
+    <%= render "tasks/run", run: run %>
   <% end %>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -3,10 +3,16 @@
 <p>Agent: <%= @task.agent.name %></p>
 <p>Project: <%= @task.project.name %></p>
 
-<div class="codex-layout">
+<div data-controller="tabs" class="codex-layout">
   <%= turbo_stream_from @task %>
-  <%= render "tasks/chat_panel", task: @task, runs: @task.runs.order(:created_at) %>
-  <div class="log-panel">
+  <div class="nav">
+    <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="chat" class="tab chat-tab">Chat</button>
+    <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="steps" class="tab -active">Runs</button>
+  </div>
+  <div data-tabs-target="panel" data-panel-id="chat" class="chat-panel">
+    <%= render "tasks/chat_panel", task: @task, runs: @task.runs.order(:created_at) %>
+  </div>
+  <div data-tabs-target="panel" data-panel-id="steps" class="log-panel -active">
     <% if @task.runs.any? %>
       <%= render "tasks/runs_list", runs: @runs %>
     <% else %>


### PR DESCRIPTION
## Summary
- use shared tab controller on task page
- show single chat panel with tabs
- adjust styles for responsive display
- clean up run views

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e2869f364832da6d0028a2963f5d4