### PR TITLE
Add scrollbars only for desktop

### DIFF
--- a/app/assets/stylesheets/chat-panel.css
+++ b/app/assets/stylesheets/chat-panel.css
@@ -1,3 +1,4 @@
+
 .chat-panel {
   display: flex;
   flex-direction: column;
@@ -6,6 +7,16 @@
 
 #chat-messages {
   flex: 1;
+}
+
+@media (min-width: 769px) {
+  .chat-panel {
+    max-height: 75vh;
+  }
+
+  #chat-messages {
+    overflow-y: auto;
+  }
 }
 
 .chat-item {

--- a/app/assets/stylesheets/codex-layout.css
+++ b/app/assets/stylesheets/codex-layout.css
@@ -33,6 +33,10 @@
 }
 
 @media (min-width: 769px) {
+  .codex-layout > .log-panel {
+    overflow-y: auto;
+    max-height: 75vh;
+  }
   .chat-tab {
     display: none;
   }


### PR DESCRIPTION
## Summary
- move log/chat scrollbars into desktop media query
- add media query in chat panel for max height and overflow

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e36543d64832d85a42d5b7e1f7836