### PR TITLE
Make task show view edge-to-edge layout

### DIFF
--- a/app/assets/stylesheets/codex-layout.css
+++ b/app/assets/stylesheets/codex-layout.css
@@ -20,11 +20,13 @@
   .codex-layout > .chat-panel,
   .codex-layout > .log-panel {
     display: none;
+    width: 100%;
   }
 
   .codex-layout > .chat-panel.-active,
   .codex-layout > .log-panel.-active {
     display: block;
+    width: 100%;
   }
 
   .chat-tab {

--- a/app/assets/stylesheets/task-show.css
+++ b/app/assets/stylesheets/task-show.css
@@ -1,11 +1,22 @@
 body.tasks.show {
-  max-width: 100%;
+  max-width: 100% !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+body.tasks.show > header,
+body.tasks.show > header > nav {
+  max-width: 100% !important;
+  width: 100% !important;
+  padding: 0 1rem !important;
 }
 
 body.tasks.show > main {
-  max-width: 100%;
-  padding: 0;
-  margin: 0;
+  max-width: 100% !important;
+  width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
 }
 
 body.tasks.show h1,
@@ -21,8 +32,14 @@ body.tasks.show p {
 
 body.tasks.show .codex-layout {
   margin: 0;
-  max-width: 100%;
+  max-width: 100% !important;
+  width: 100% !important;
   padding: 0 1rem;
+}
+
+body.tasks.show .chat-panel,
+body.tasks.show .log-panel {
+  max-width: 100% !important;
 }
 
 body.tasks.show .task-actions {

--- a/app/assets/stylesheets/task-show.css
+++ b/app/assets/stylesheets/task-show.css
@@ -16,11 +16,15 @@ html body.tasks.show header {
   width: 100% !important;
   margin: 0 !important;
   grid-column: unset !important;
+  background-color: transparent !important;
+  border-bottom: none !important;
+  padding: 0 !important;
 }
 
 html body.tasks.show header nav {
   max-width: 100% !important;
   width: 100% !important;
+  padding: 1rem 0 !important;
 }
 
 html body.tasks.show header nav ul {
@@ -33,6 +37,7 @@ html body.tasks.show main {
   width: 100% !important;
   padding: 0 !important;
   margin: 0 !important;
+  padding-top: 0 !important;
 }
 
 body.tasks.show h1,

--- a/app/assets/stylesheets/task-show.css
+++ b/app/assets/stylesheets/task-show.css
@@ -1,0 +1,30 @@
+body.tasks.show {
+  max-width: 100%;
+}
+
+body.tasks.show > main {
+  max-width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+body.tasks.show h1,
+body.tasks.show h2,
+body.tasks.show h3,
+body.tasks.show h4,
+body.tasks.show h5,
+body.tasks.show h6,
+body.tasks.show p {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+body.tasks.show .codex-layout {
+  margin: 0;
+  max-width: 100%;
+  padding: 0 1rem;
+}
+
+body.tasks.show .task-actions {
+  margin: 1rem;
+}

--- a/app/assets/stylesheets/task-show.css
+++ b/app/assets/stylesheets/task-show.css
@@ -16,6 +16,7 @@ html body.tasks.show header {
   width: 100% !important;
   margin: 0 !important;
   grid-column: unset !important;
+  padding-bottom: 0 !important;
 }
 
 html body.tasks.show header nav {

--- a/app/assets/stylesheets/task-show.css
+++ b/app/assets/stylesheets/task-show.css
@@ -22,6 +22,7 @@ html body.tasks.show header {
 html body.tasks.show header nav {
   max-width: 100% !important;
   width: 100% !important;
+  margin: 0 !important;
 }
 
 html body.tasks.show header nav ul {

--- a/app/assets/stylesheets/task-show.css
+++ b/app/assets/stylesheets/task-show.css
@@ -16,15 +16,11 @@ html body.tasks.show header {
   width: 100% !important;
   margin: 0 !important;
   grid-column: unset !important;
-  background-color: transparent !important;
-  border-bottom: none !important;
-  padding: 0 !important;
 }
 
 html body.tasks.show header nav {
   max-width: 100% !important;
   width: 100% !important;
-  padding: 1rem 0 !important;
 }
 
 html body.tasks.show header nav ul {
@@ -37,7 +33,6 @@ html body.tasks.show main {
   width: 100% !important;
   padding: 0 !important;
   margin: 0 !important;
-  padding-top: 0 !important;
 }
 
 body.tasks.show h1,

--- a/app/assets/stylesheets/task-show.css
+++ b/app/assets/stylesheets/task-show.css
@@ -1,18 +1,34 @@
-body.tasks.show {
+html body.tasks.show {
   max-width: 100% !important;
   width: 100% !important;
   margin: 0 !important;
   padding: 0 !important;
+  display: block !important;
+  grid-template-columns: none !important;
 }
 
-body.tasks.show > header,
-body.tasks.show > header > nav {
+html body.tasks.show > * {
+  grid-column: unset !important;
+}
+
+html body.tasks.show header {
   max-width: 100% !important;
   width: 100% !important;
+  margin: 0 !important;
+  grid-column: unset !important;
+}
+
+html body.tasks.show header nav {
+  max-width: 100% !important;
+  width: 100% !important;
+}
+
+html body.tasks.show header nav ul {
+  max-width: 100% !important;
   padding: 0 1rem !important;
 }
 
-body.tasks.show > main {
+html body.tasks.show main {
   max-width: 100% !important;
   width: 100% !important;
   padding: 0 !important;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/diff2html/bundles/js/diff2html-ui.min.js"></script>
   </head>
 
-  <body>
+  <body class="<%= controller_name %> <%= action_name %>">
     <%= render "nav" %>
     <main>
       <div id="flash-messages">


### PR DESCRIPTION
## Summary
- Override simple.css grid layout to achieve full-width task view
- Add controller/action classes to body tag for targeted styling
- Fix mobile view to use full width for tabbed panels

## Changes
- Created `task-show.css` to override simple.css centering
- Disabled CSS Grid on body and removed grid-column constraints
- Fixed header/nav spacing issues
- Made mobile chat/run panels full width

## Test plan
- [x] Verify task show view spans full width on desktop
- [x] Check that other pages still use centered layout
- [x] Test mobile view tab switching works properly
- [x] Ensure nav bar styling is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)