### PR TITLE
Fix dark mode chat readability

### DIFF
--- a/app/assets/stylesheets/chat-panel.css
+++ b/app/assets/stylesheets/chat-panel.css
@@ -37,3 +37,15 @@
 .chat-item > .assistant-message {
   background: #f0f0f0;
 }
+
+@media (prefers-color-scheme: dark) {
+  .chat-item > .user-message {
+    background: #0f2a3f;
+    color: #e6e6e6;
+  }
+
+  .chat-item > .assistant-message {
+    background: #2d2d2d;
+    color: #e6e6e6;
+  }
+}


### PR DESCRIPTION
## Summary
- update styles for chat messages in dark mode

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e6bb103ec832d8a28489b7c774353