### PR TITLE
Update text log processor

### DIFF
--- a/app/models/log_processor/text.rb
+++ b/app/models/log_processor/text.rb
@@ -1,5 +1,8 @@
 class LogProcessor::Text < LogProcessor
   def process(logs)
-    [ { raw_response: logs, type: "Step::Text", content: logs } ]
+    [
+      { raw_response: logs, type: "Step::Text", content: logs },
+      { raw_response: logs, type: "Step::Result", content: logs }
+    ]
   end
 end

--- a/test/models/log_processor/text_test.rb
+++ b/test/models/log_processor/text_test.rb
@@ -1,20 +1,22 @@
 require "test_helper"
 
 class LogProcessor::TextTest < ActiveSupport::TestCase
-  test "process returns single step with logs" do
+  test "process returns text and result steps" do
     processor = LogProcessor::Text.new
     logs = "Multi-line\nlog output\nwith text"
     result = processor.process(logs)
 
-    assert_equal 1, result.size
-    assert_equal({ raw_response: logs, type: "Step::Text", content: logs }, result.first)
+    assert_equal 2, result.size
+    assert_equal({ raw_response: logs, type: "Step::Text", content: logs }, result[0])
+    assert_equal({ raw_response: logs, type: "Step::Result", content: logs }, result[1])
   end
 
   test "class method process works" do
     logs = "Test log output"
     result = LogProcessor::Text.process(logs)
 
-    assert_equal 1, result.size
-    assert_equal({ raw_response: logs, type: "Step::Text", content: logs }, result.first)
+    assert_equal 2, result.size
+    assert_equal({ raw_response: logs, type: "Step::Text", content: logs }, result[0])
+    assert_equal({ raw_response: logs, type: "Step::Result", content: logs }, result[1])
   end
 end

--- a/test/models/run_log_processing_test.rb
+++ b/test/models/run_log_processing_test.rb
@@ -45,8 +45,10 @@ class RunLogProcessingTest < ActiveSupport::TestCase
     step_data_list = processor.process(text_logs)
     step_data_list.each { |step_data| run.steps.create!(step_data) }
 
-    assert_equal 1, run.steps.count
+    assert_equal 2, run.steps.count
     assert_equal "Step::Text", run.steps.first.type
     assert_equal text_logs, run.steps.first.content
+    assert_equal "Step::Result", run.steps.second.type
+    assert_equal text_logs, run.steps.second.content
   end
 end

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -88,7 +88,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
     assert_equal "hello world", run.steps.first.raw_response
     assert run.steps.last.content.start_with?("Repository state captured")
   end
@@ -108,7 +108,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
     assert_equal "continued output", run.steps.first.raw_response
   end
 
@@ -163,7 +163,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
   end
 
   test "execute! clones repository on first run with default repo_path" do
@@ -184,7 +184,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
   end
 
   test "execute! clones repository on first run with custom repo_path" do
@@ -205,7 +205,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
   end
 
   test "execute! handles git clone failure" do
@@ -242,7 +242,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
   end
 
   test "should_clone_repository? returns false when repository_url is blank" do
@@ -269,7 +269,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 1, run.steps.count # No repo state step since no repository_url
+    assert_equal 2, run.steps.count # No repo state step since no repository_url
   end
 
   test "execute! runs setup script on first run when present" do
@@ -289,7 +289,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 3, run.steps.count
+    assert_equal 4, run.steps.count
     setup_step = run.steps.find { |s| s.content&.start_with?("Setup script executed") }
     assert_not_nil setup_step
     assert_includes setup_step.content, "Setup complete!"
@@ -309,7 +309,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
     assert_nil run.steps.find { |s| s.content&.start_with?("Setup script executed") }
   end
 
@@ -352,7 +352,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 3, run.steps.count
+    assert_equal 4, run.steps.count
   end
 
   test "execute! configures MCP on first run when endpoint present" do
@@ -370,7 +370,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
   end
 
   test "execute! appends /mcp/sse to endpoint URL if not present" do
@@ -417,7 +417,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
   end
 
   test "execute! skips MCP configuration when endpoint is blank" do
@@ -431,7 +431,7 @@ class RunTest < ActiveSupport::TestCase
     run.execute!
 
     assert run.completed?
-    assert_equal 2, run.steps.count
+    assert_equal 3, run.steps.count
   end
 
   test "execute! handles MCP configuration failure" do


### PR DESCRIPTION
## Summary
- show `Step::Result` when using the Text log processor
- update tests for new log step counts

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e73f9c684832d830f2f9b4103331f