### PR TITLE
Fix OAuth reconfiguration with new Docker image

### DIFF
--- a/app/models/claude_oauth.rb
+++ b/app/models/claude_oauth.rb
@@ -1,7 +1,7 @@
 require "docker"
 
 class ClaudeOauth
-  OAUTH_IMAGE = "claude_oauth:latest"
+  OAUTH_IMAGE = "joedupuis/claude_oauth:latest"
   VOLUME_NAME = "claude_config"
 
   def initialize(agent)
@@ -14,7 +14,7 @@ class ClaudeOauth
     ensure_image_exists
 
     container = create_oauth_container(
-      [ "/home/claude/login_start.rb" ]
+      [ "login_start" ]
     )
 
     container.start
@@ -39,7 +39,7 @@ class ClaudeOauth
     ensure_image_exists
 
     container = create_oauth_container(
-      [ "/home/claude/login_finish.rb", authorization_code ]
+      [ "login_finish", authorization_code ]
     )
 
     container.start
@@ -63,7 +63,7 @@ class ClaudeOauth
     ensure_image_exists
 
     container = create_oauth_container(
-      [ "/home/claude/refresh_token.rb", "--force" ]
+      [ "refresh_token", "--force" ]
     )
 
     container.start
@@ -151,7 +151,6 @@ class ClaudeOauth
   def create_oauth_container(command)
     Docker::Container.create(
       "Image" => OAUTH_IMAGE,
-      "Entrypoint" => [ "ruby" ],
       "Cmd" => command,
       "User" => @agent.user_id.to_s,
       "HostConfig" => {


### PR DESCRIPTION
## Summary
- Fixed OAuth reconfiguration failing with \"ruby executable not found\" error when using `joedupuis/claude_oauth:latest` image

## Problem
When clicking \"Reconfigure OAuth\" with the new Docker image, it was failing with:
```
exec: "ruby": executable file not found in $PATH: unknown
```

## Solution
- Updated the image name to use the full path `joedupuis/claude_oauth:latest`
- Removed the Ruby entrypoint override since the new image has a special entrypoint
- Changed OAuth commands to use simple command names that the entrypoint understands:
  - `login_start` instead of `/home/claude/login_start.rb`
  - `login_finish` instead of `/home/claude/login_finish.rb`
  - `refresh_token` instead of `/home/claude/refresh_token.rb`

## Testing
- All tests pass
- Linter clean
- Security analysis clean