### PR TITLE
Fix claude state isolation by mounting ~/.claude/projects as task-specific volume

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,6 +59,10 @@ if Rails.env.development?
     volume.external_name = "claude_config"
   end
 
+  Volume.find_or_create_by!(agent: claude_agent, name: "claude_projects") do |volume|
+    volume.path = "/home/claude/.claude/projects"
+  end
+
   ClaudeOauthSetting.find_or_create_by!(agent: claude_agent)
 
   claude_json_agent = Agent.find_or_create_by!(name: "Claude Json") do |agent|
@@ -82,6 +86,10 @@ if Rails.env.development?
     volume.external_name = "claude_config"
   end
 
+  Volume.find_or_create_by!(agent: claude_json_agent, name: "claude_projects") do |volume|
+    volume.path = "/home/claude/.claude/projects"
+  end
+
   ClaudeOauthSetting.find_or_create_by!(agent: claude_json_agent)
 
   claude_streaming_agent = Agent.find_or_create_by!(name: "Claude Streaming") do |agent|
@@ -103,6 +111,10 @@ if Rails.env.development?
     volume.path = "/home/claude/.claude"
     volume.external = true
     volume.external_name = "claude_config"
+  end
+
+  Volume.find_or_create_by!(agent: claude_streaming_agent, name: "claude_projects") do |volume|
+    volume.path = "/home/claude/.claude/projects"
   end
 
   ClaudeOauthSetting.find_or_create_by!(agent: claude_streaming_agent)


### PR DESCRIPTION
## Summary
- Added task-specific volume mounts for `~/.claude/projects` directory
- Prevents state conflicts between concurrent tasks
- Each task now gets its own isolated volume instance

The issue was that all tasks were sharing the same `~/.claude/projects` directory because it was part of the external claude_config volume. This caused state conflicts when multiple tasks ran concurrently.

The fix adds a new non-external volume for `~/.claude/projects` to each Claude agent in the seeds. Since it's not external, each task gets its own unique volume instance through the `create_volume_mounts` callback.

🤖 Generated with [Claude Code](https://claude.ai/code)