### PR TITLE
Remove dashboard footer links

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -5,7 +5,3 @@
 <h2>Recent Tasks</h2>
 <%= render 'tasks/task_list' %>
 
-<p>
-  <%= link_to 'Projects', projects_path %> |
-  <%= link_to 'Agents', agents_path %>
-</p>


### PR DESCRIPTION
## Summary
- delete redundant links for Projects and Agents in Dashboard

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bundle exec brakeman --no-pager -q`


------
https://chatgpt.com/codex/tasks/task_e_6850bd4826e8832d86a26ff953a9d425