### PR TITLE
Enable Docker registry cache in deploy

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -78,6 +78,10 @@ asset_path: /rails/public/assets
 # Configure the image builder.
 builder:
   arch: amd64
+  cache:
+    type: registry
+    options: mode=max
+    image: summoncircle-build-cache
 
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
   # remote: ssh://docker@docker-builder-server


### PR DESCRIPTION
## Summary
- enable Docker buildx registry cache

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850c7bc55f8832db8572af45959f7a5