### PR TITLE
Add cost tracking for agent runs

### DIFF
--- a/app/models/log_processor/concerns/claude_json_processing.rb
+++ b/app/models/log_processor/concerns/claude_json_processing.rb
@@ -33,7 +33,17 @@ module LogProcessor::Concerns::ClaudeJsonProcessing
       tool_use_id = extract_tool_result_id(item)
       { raw_response: item_json, type: "Step::ToolResult", content: extract_content(item), tool_use_id: tool_use_id }
     when "result"
-      { raw_response: item_json, type: "Step::Result", content: item["result"] || extract_content(item) }
+      step_data = { raw_response: item_json, type: "Step::Result", content: item["result"] || extract_content(item) }
+      if item["total_cost_usd"]
+        step_data[:cost_usd] = item["total_cost_usd"]
+      end
+      if item["usage"]
+        step_data[:input_tokens] = item["usage"]["input_tokens"]
+        step_data[:output_tokens] = item["usage"]["output_tokens"]
+        step_data[:cache_creation_tokens] = item["usage"]["cache_creation_input_tokens"]
+        step_data[:cache_read_tokens] = item["usage"]["cache_read_input_tokens"]
+      end
+      step_data
     else
       { raw_response: item_json, type: "Step::Text", content: extract_content(item) }
     end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -77,6 +77,19 @@ class Run < ApplicationRecord
       locals: { task: task })
   end
 
+  def total_cost
+    steps.where.not(cost_usd: nil).sum(:cost_usd)
+  end
+
+  def total_tokens
+    {
+      input: steps.where.not(input_tokens: nil).sum(:input_tokens),
+      output: steps.where.not(output_tokens: nil).sum(:output_tokens),
+      cache_creation: steps.where.not(cache_creation_tokens: nil).sum(:cache_creation_tokens),
+      cache_read: steps.where.not(cache_read_tokens: nil).sum(:cache_read_tokens)
+    }
+  end
+
   private
 
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -26,6 +26,19 @@ class Task < ApplicationRecord
     @branches ||= fetch_branches(self)
   end
 
+  def total_cost
+    runs.joins(:steps).where.not(steps: { cost_usd: nil }).sum("steps.cost_usd")
+  end
+
+  def total_tokens
+    {
+      input: runs.joins(:steps).where.not(steps: { input_tokens: nil }).sum("steps.input_tokens"),
+      output: runs.joins(:steps).where.not(steps: { output_tokens: nil }).sum("steps.output_tokens"),
+      cache_creation: runs.joins(:steps).where.not(steps: { cache_creation_tokens: nil }).sum("steps.cache_creation_tokens"),
+      cache_read: runs.joins(:steps).where.not(steps: { cache_read_tokens: nil }).sum("steps.cache_read_tokens")
+    }
+  end
+
 
   private
 

--- a/app/views/tasks/_run.html.erb
+++ b/app/views/tasks/_run.html.erb
@@ -7,6 +7,9 @@
     <% if run.completed_at %>
       | <strong>Completed:</strong> <%= run.completed_at.strftime("%Y-%m-%d %H:%M:%S") %>
     <% end %>
+    <% if run.total_cost > 0 %>
+      | <strong>Cost:</strong> $<%= "%.6f" % run.total_cost %>
+    <% end %>
   </p>
   <%= render "runs/tabs", run: run %>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,6 +2,9 @@
 
 <p>Agent: <%= @task.agent.name %></p>
 <p>Project: <%= @task.project.name %></p>
+<% if @task.total_cost > 0 %>
+  <p>Total Cost: $<%= "%.6f" % @task.total_cost %></p>
+<% end %>
 
 <div data-controller="tabs" class="codex-layout">
   <%= turbo_stream_from @task %>

--- a/db/migrate/20250617014540_add_cost_tracking_to_steps.rb
+++ b/db/migrate/20250617014540_add_cost_tracking_to_steps.rb
@@ -1,0 +1,9 @@
+class AddCostTrackingToSteps < ActiveRecord::Migration[8.0]
+  def change
+    add_column :steps, :cost_usd, :decimal, precision: 10, scale: 8
+    add_column :steps, :input_tokens, :integer
+    add_column :steps, :output_tokens, :integer
+    add_column :steps, :cache_creation_tokens, :integer
+    add_column :steps, :cache_read_tokens, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_17_014540) do
   create_table "agent_specific_settings", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.string "type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_id", "type" ], name: "index_agent_specific_settings_on_agent_id_and_type", unique: true
-    t.index [ "agent_id" ], name: "index_agent_specific_settings_on_agent_id"
+    t.index ["agent_id", "type"], name: "index_agent_specific_settings_on_agent_id_and_type", unique: true
+    t.index ["agent_id"], name: "index_agent_specific_settings_on_agent_id"
   end
 
   create_table "agents", force: :cascade do |t|
@@ -37,7 +37,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.string "ssh_mount_path"
     t.string "home_path"
     t.string "mcp_sse_endpoint"
-    t.index [ "discarded_at" ], name: "index_agents_on_discarded_at"
+    t.index ["discarded_at"], name: "index_agents_on_discarded_at"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -49,7 +49,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
     t.string "repo_path"
-    t.index [ "discarded_at" ], name: "index_projects_on_discarded_at"
+    t.index ["discarded_at"], name: "index_projects_on_discarded_at"
   end
 
   create_table "repo_states", force: :cascade do |t|
@@ -59,7 +59,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.integer "step_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "step_id" ], name: "index_repo_states_on_step_id"
+    t.index ["step_id"], name: "index_repo_states_on_step_id"
   end
 
   create_table "runs", force: :cascade do |t|
@@ -70,7 +70,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "task_id" ], name: "index_runs_on_task_id"
+    t.index ["task_id"], name: "index_runs_on_task_id"
   end
 
   create_table "secrets", force: :cascade do |t|
@@ -79,8 +79,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "project_id", "key" ], name: "index_secrets_on_project_id_and_key", unique: true
-    t.index [ "project_id" ], name: "index_secrets_on_project_id"
+    t.index ["project_id", "key"], name: "index_secrets_on_project_id_and_key", unique: true
+    t.index ["project_id"], name: "index_secrets_on_project_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -89,7 +89,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.string "user_agent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "user_id" ], name: "index_sessions_on_user_id"
+    t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "steps", force: :cascade do |t|
@@ -101,10 +101,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.text "content"
     t.integer "tool_call_id"
     t.string "tool_use_id"
-    t.index [ "run_id", "tool_use_id" ], name: "index_steps_on_run_id_and_tool_use_id"
-    t.index [ "run_id" ], name: "index_steps_on_run_id"
-    t.index [ "tool_call_id" ], name: "index_steps_on_tool_call_id"
-    t.index [ "type" ], name: "index_steps_on_type"
+    t.decimal "cost_usd", precision: 10, scale: 8
+    t.integer "input_tokens"
+    t.integer "output_tokens"
+    t.integer "cache_creation_tokens"
+    t.integer "cache_read_tokens"
+    t.index ["run_id", "tool_use_id"], name: "index_steps_on_run_id_and_tool_use_id"
+    t.index ["run_id"], name: "index_steps_on_run_id"
+    t.index ["tool_call_id"], name: "index_steps_on_tool_call_id"
+    t.index ["type"], name: "index_steps_on_type"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -119,10 +124,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.integer "user_id", null: false
     t.boolean "auto_push_enabled", default: false, null: false
     t.string "auto_push_branch"
-    t.index [ "agent_id" ], name: "index_tasks_on_agent_id"
-    t.index [ "discarded_at" ], name: "index_tasks_on_discarded_at"
-    t.index [ "project_id" ], name: "index_tasks_on_project_id"
-    t.index [ "user_id" ], name: "index_tasks_on_user_id"
+    t.index ["agent_id"], name: "index_tasks_on_agent_id"
+    t.index ["discarded_at"], name: "index_tasks_on_discarded_at"
+    t.index ["project_id"], name: "index_tasks_on_project_id"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -135,7 +140,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.text "instructions"
     t.text "ssh_key"
     t.text "git_config"
-    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
   create_table "volume_mounts", force: :cascade do |t|
@@ -144,8 +149,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "volume_name"
-    t.index [ "task_id" ], name: "index_volume_mounts_on_task_id"
-    t.index [ "volume_id" ], name: "index_volume_mounts_on_volume_id"
+    t.index ["task_id"], name: "index_volume_mounts_on_task_id"
+    t.index ["volume_id"], name: "index_volume_mounts_on_volume_id"
   end
 
   create_table "volumes", force: :cascade do |t|
@@ -156,7 +161,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "updated_at", null: false
     t.boolean "external", default: false
     t.string "external_name"
-    t.index [ "agent_id" ], name: "index_volumes_on_agent_id"
+    t.index ["agent_id"], name: "index_volumes_on_agent_id"
   end
 
   add_foreign_key "agent_specific_settings", "agents"


### PR DESCRIPTION
## Summary
- Add database migration to track cost and token usage per step
- Automatically capture cost data from Claude API responses  
- Display cost information in task and run views

## Implementation Details
- Added columns to steps table: cost_usd, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens
- Modified ClaudeJsonProcessing to extract cost data from result steps
- Added helper methods to Run and Task models for calculating total costs
- Updated views to display cost information

## Test plan
- [x] All existing tests pass
- [x] Rubocop linter passes
- [x] Brakeman security scan passes
- [ ] Manually verify cost tracking works with real Claude API calls
- [ ] Verify cost display in UI shows correctly formatted values