### PR TITLE
Add agent duplication functionality

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -17,7 +17,12 @@ class AgentsController < ApplicationController
       @agent.name = "Copy of #{source_agent.name}"
 
       @agent.volumes_config = source_agent.volumes_config
-      @agent.agent_specific_setting_type = source_agent.agent_specific_settings.first&.type
+
+      if source_agent.agent_specific_settings.any?
+        source_setting = source_agent.agent_specific_settings.first
+        @agent.agent_specific_setting_type = source_setting.type
+        @agent.agent_specific_settings.build(type: source_setting.type)
+      end
     end
   end
 

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -10,6 +10,15 @@ class AgentsController < ApplicationController
 
   def new
     @agent = Agent.new
+
+    if params[:source_id].present?
+      source_agent = Agent.find(params[:source_id])
+      @agent = source_agent.dup
+      @agent.name = "Copy of #{source_agent.name}"
+
+      @agent.volumes_config = source_agent.volumes_config
+      @agent.agent_specific_setting_type = source_agent.agent_specific_settings.first&.type
+    end
   end
 
   def create

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -116,5 +116,6 @@
   <%= link_to 'Archive', agent_path(@agent), 
               data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this agent?' },
               class: 'archive' %> |
+  <%= link_to 'Clone', new_agent_path(source_id: @agent.id) %> |
   <%= link_to 'Back', agents_path %>
 </div>


### PR DESCRIPTION
## Summary
- Added ability to duplicate agents with a "Clone" button
- Duplicated agents get "Copy of" prefix and open in edit form
- Uses RESTful routes without custom actions

## Implementation
- Modified `agents#new` to handle cloning when `source_id` parameter is present
- Added Clone link to agent show page that passes source ID to new action
- Preserves all agent settings including volumes and agent-specific settings

🤖 Generated with [Claude Code](https://claude.ai/code)