### PR TITLE
Fix registry cache authentication error

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -81,7 +81,7 @@ builder:
   cache:
     type: registry
     options: mode=max
-    image: summoncircle-build-cache
+    image: joedupuis/summoncircle-build-cache
 
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
   # remote: ssh://docker@docker-builder-server


### PR DESCRIPTION
## Summary
- Fixed Docker registry cache push authentication error by adding the missing `joedupuis/` prefix to the cache image name
- Changed `summoncircle-build-cache` to `joedupuis/summoncircle-build-cache` in `config/deploy.yml`

This resolves the "push access denied, repository does not exist or may require authorization" error that was occurring during the cache export step of the build process.