### PR TITLE
Add task description editing

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   before_action :set_project
-  before_action :set_task, only: [ :show, :destroy, :branches, :update_auto_push ]
+  before_action :set_task, only: [ :show, :destroy, :branches, :update_auto_push, :edit_description, :update_description ]
 
   def index
     @tasks = @project.tasks.kept.includes(:agent, :project)
@@ -83,6 +83,18 @@ class TasksController < ApplicationController
     end
   end
 
+  def edit_description
+    render partial: "tasks/description_form", locals: { task: @task }
+  end
+
+  def update_description
+    if @task.update(description_params)
+      render partial: "tasks/description", locals: { task: @task }
+    else
+      render partial: "tasks/description_form", locals: { task: @task }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_project
@@ -98,10 +110,14 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:agent_id, :project_id)
+    params.require(:task).permit(:agent_id, :project_id, :description)
   end
 
   def auto_push_params
     params.require(:task).permit(:auto_push_enabled, :auto_push_branch)
+  end
+
+  def description_params
+    params.require(:task).permit(:description)
   end
 end

--- a/app/views/tasks/_description.html.erb
+++ b/app/views/tasks/_description.html.erb
@@ -1,0 +1,2 @@
+<% desc = task.description.presence || "#{task.agent.name} in #{task.project.name}" %>
+<p><%= desc %> <%= link_to 'Edit', edit_description_task_path(task), data: { turbo_frame: dom_id(task, :description) } %></p>

--- a/app/views/tasks/_description_form.html.erb
+++ b/app/views/tasks/_description_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: task, url: update_description_task_path(task), method: :patch, data: { turbo_frame: dom_id(task, :description) } do |form| %>
+  <%= form.text_field :description, placeholder: "Description" %>
+  <%= form.submit 'Save', class: 'button action-button -primary -mini' %>
+<% end %>

--- a/app/views/tasks/_task_form.html.erb
+++ b/app/views/tasks/_task_form.html.erb
@@ -22,6 +22,11 @@
     </div>
   </div>
 
+  <div class="field">
+    <%= form.label :description %><br>
+    <%= form.text_field :description %>
+  </div>
+
   <div data-controller="prompt">
     <%= form.label :prompt %><br>
     <%= form.text_area :prompt, data: { prompt_target: "textarea", action: "keydown->prompt#keydown" } %>

--- a/app/views/tasks/_task_list.html.erb
+++ b/app/views/tasks/_task_list.html.erb
@@ -2,9 +2,15 @@
   <% @tasks.each do |task| %>
     <li>
       <%= link_to "Task ##{task.id}", task_path(task) %> -
-      <%= task.agent.name %>
+      <% if task.description.present? %>
+        <%= task.description %>
+      <% else %>
+        <%= task.agent.name %>
+        <% unless @project %>
+          in <%= task.project.name %>
+        <% end %>
+      <% end %>
       <% unless @project %>
-        in <%= task.project.name %>
         (<%= task.created_at.strftime("%m/%d %H:%M") %>)
       <% end %>
     </li>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,5 +1,9 @@
 <h1>Task <%= @task.id %></h1>
 
+<%= turbo_frame_tag dom_id(@task, :description) do %>
+  <%= render "tasks/description", task: @task %>
+<% end %>
+
 <p>Agent: <%= @task.agent.name %></p>
 <p>Project: <%= @task.project.name %></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
       member do
         get :branches
         patch :update_auto_push
+        get :edit_description
+        patch :update_description
       end
       resources :runs, only: %i[create]
     end

--- a/db/migrate/20250617011926_add_description_to_tasks.rb
+++ b/db/migrate/20250617011926_add_description_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToTasks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tasks, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_17_011926) do
   create_table "agent_specific_settings", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.string "type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_id", "type" ], name: "index_agent_specific_settings_on_agent_id_and_type", unique: true
-    t.index [ "agent_id" ], name: "index_agent_specific_settings_on_agent_id"
+    t.index ["agent_id", "type"], name: "index_agent_specific_settings_on_agent_id_and_type", unique: true
+    t.index ["agent_id"], name: "index_agent_specific_settings_on_agent_id"
   end
 
   create_table "agents", force: :cascade do |t|
@@ -37,7 +37,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.string "ssh_mount_path"
     t.string "home_path"
     t.string "mcp_sse_endpoint"
-    t.index [ "discarded_at" ], name: "index_agents_on_discarded_at"
+    t.index ["discarded_at"], name: "index_agents_on_discarded_at"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -49,7 +49,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
     t.string "repo_path"
-    t.index [ "discarded_at" ], name: "index_projects_on_discarded_at"
+    t.index ["discarded_at"], name: "index_projects_on_discarded_at"
   end
 
   create_table "repo_states", force: :cascade do |t|
@@ -59,7 +59,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.integer "step_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "step_id" ], name: "index_repo_states_on_step_id"
+    t.index ["step_id"], name: "index_repo_states_on_step_id"
   end
 
   create_table "runs", force: :cascade do |t|
@@ -70,7 +70,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "task_id" ], name: "index_runs_on_task_id"
+    t.index ["task_id"], name: "index_runs_on_task_id"
   end
 
   create_table "secrets", force: :cascade do |t|
@@ -79,8 +79,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "project_id", "key" ], name: "index_secrets_on_project_id_and_key", unique: true
-    t.index [ "project_id" ], name: "index_secrets_on_project_id"
+    t.index ["project_id", "key"], name: "index_secrets_on_project_id_and_key", unique: true
+    t.index ["project_id"], name: "index_secrets_on_project_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -89,7 +89,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.string "user_agent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "user_id" ], name: "index_sessions_on_user_id"
+    t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "steps", force: :cascade do |t|
@@ -101,10 +101,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.text "content"
     t.integer "tool_call_id"
     t.string "tool_use_id"
-    t.index [ "run_id", "tool_use_id" ], name: "index_steps_on_run_id_and_tool_use_id"
-    t.index [ "run_id" ], name: "index_steps_on_run_id"
-    t.index [ "tool_call_id" ], name: "index_steps_on_tool_call_id"
-    t.index [ "type" ], name: "index_steps_on_type"
+    t.index ["run_id", "tool_use_id"], name: "index_steps_on_run_id_and_tool_use_id"
+    t.index ["run_id"], name: "index_steps_on_run_id"
+    t.index ["tool_call_id"], name: "index_steps_on_tool_call_id"
+    t.index ["type"], name: "index_steps_on_type"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -119,10 +119,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.integer "user_id", null: false
     t.boolean "auto_push_enabled", default: false, null: false
     t.string "auto_push_branch"
-    t.index [ "agent_id" ], name: "index_tasks_on_agent_id"
-    t.index [ "discarded_at" ], name: "index_tasks_on_discarded_at"
-    t.index [ "project_id" ], name: "index_tasks_on_project_id"
-    t.index [ "user_id" ], name: "index_tasks_on_user_id"
+    t.string "description"
+    t.index ["agent_id"], name: "index_tasks_on_agent_id"
+    t.index ["discarded_at"], name: "index_tasks_on_discarded_at"
+    t.index ["project_id"], name: "index_tasks_on_project_id"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -135,7 +136,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.text "instructions"
     t.text "ssh_key"
     t.text "git_config"
-    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
   create_table "volume_mounts", force: :cascade do |t|
@@ -144,8 +145,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "volume_name"
-    t.index [ "task_id" ], name: "index_volume_mounts_on_task_id"
-    t.index [ "volume_id" ], name: "index_volume_mounts_on_volume_id"
+    t.index ["task_id"], name: "index_volume_mounts_on_task_id"
+    t.index ["volume_id"], name: "index_volume_mounts_on_volume_id"
   end
 
   create_table "volumes", force: :cascade do |t|
@@ -156,7 +157,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_021535) do
     t.datetime "updated_at", null: false
     t.boolean "external", default: false
     t.string "external_name"
-    t.index [ "agent_id" ], name: "index_volumes_on_agent_id"
+    t.index ["agent_id"], name: "index_volumes_on_agent_id"
   end
 
   add_foreign_key "agent_specific_settings", "agents"


### PR DESCRIPTION
## Summary
- allow tasks to store a description
- show description in task list when present
- edit description inline on task show page via Turbo

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bundle exec brakeman --no-pager`

------
https://chatgpt.com/codex/tasks/task_e_6850c2017d48832d9c4a3af2b05dcee7