### PR TITLE
Order tasks by creation date in descending order

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [ :show, :edit, :update, :destroy, :branches, :update_auto_push ]
 
   def index
-    @tasks = @project.tasks.kept.includes(:agent, :project)
+    @tasks = @project.tasks.kept.includes(:agent, :project).order(created_at: :desc)
   end
 
   def show


### PR DESCRIPTION
Update tasks#index to display tasks ordered by created_at in descending order (newest first) to match the dashboard behavior and provide consistent task ordering across the application.

🤖 Generated with [Claude Code](https://claude.ai/code)