### PR TITLE
Remove prompt label from tasks show page

### DIFF
--- a/app/views/tasks/_run_form.html.erb
+++ b/app/views/tasks/_run_form.html.erb
@@ -1,6 +1,5 @@
 <%= form_with model: [@task, run], id: "run-form", class: "run-form", data: { controller: "prompt", action: "turbo:submit-end->prompt#clearForm" } do |form| %>
   <div class="field">
-    <%= form.label :prompt %><br>
     <%= form.text_area :prompt, required: true, rows: 4, class: "textarea", data: { prompt_target: "textarea", action: "keydown->prompt#keydown" } %>
     <% if run.errors.any? %>
       <div class="errors">


### PR DESCRIPTION
## Summary
- Removed the "Prompt" label from the tasks show page to save vertical space
- The textarea remains functional without the label

## Changes
- Removed `<%= form.label :prompt %><br>` from `app/views/tasks/_run_form.html.erb`

## Test plan
- [x] Visual inspection shows the prompt label is removed
- [x] Textarea functionality remains intact
- [x] No linting errors

🤖 Generated with [Claude Code](https://claude.ai/code)