### PR TITLE
Add resizable panels to task view

### DIFF
--- a/app/assets/stylesheets/codex-layout.css
+++ b/app/assets/stylesheets/codex-layout.css
@@ -1,11 +1,26 @@
+
 .codex-layout {
   display: flex;
-  gap: 20px;
+  gap: 0;
 }
 
 
 .codex-layout > .chat-panel {
   width: 40%;
+}
+
+.codex-layout > .divider {
+  width: 4px;
+  margin: 0 10px;
+  cursor: col-resize;
+  background: var(--border);
+  display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+  .codex-layout > .divider {
+    background: #404040;
+  }
 }
 
 .codex-layout > .log-panel {
@@ -18,7 +33,8 @@
   }
 
   .codex-layout > .chat-panel,
-  .codex-layout > .log-panel {
+  .codex-layout > .log-panel,
+  .codex-layout > .divider {
     display: none;
     width: 100%;
   }

--- a/app/javascript/controllers/resizable_panels_controller.js
+++ b/app/javascript/controllers/resizable_panels_controller.js
@@ -1,0 +1,63 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["chat", "log", "divider"]
+  static values = { mobileBreakpoint: { type: Number, default: 768 } }
+
+  connect() {
+    this.boundMouseMove = this.onMouseMove.bind(this)
+    this.boundMouseUp = this.stopResize.bind(this)
+    this.updateVisibility()
+    window.addEventListener("resize", this.updateVisibility.bind(this))
+  }
+
+  disconnect() {
+    window.removeEventListener("resize", this.updateVisibility.bind(this))
+    this.stopResize()
+  }
+
+  startResize(event) {
+    if (this.isMobile()) return
+    this.isResizing = true
+    document.addEventListener("mousemove", this.boundMouseMove)
+    document.addEventListener("mouseup", this.boundMouseUp)
+    event.preventDefault()
+  }
+
+  onMouseMove(event) {
+    if (!this.isResizing) return
+
+    const rect = this.element.getBoundingClientRect()
+    const containerWidth = rect.width
+    let newChatWidth = event.clientX - rect.left
+
+    const min = containerWidth * 0.1
+    const max = containerWidth * 0.9
+    newChatWidth = Math.min(Math.max(newChatWidth, min), max)
+
+    const chatPercent = (newChatWidth / containerWidth) * 100
+    this.chatTarget.style.width = `${chatPercent}%`
+    this.logTarget.style.width = `${100 - chatPercent}%`
+  }
+
+  stopResize() {
+    if (!this.isResizing) return
+    this.isResizing = false
+    document.removeEventListener("mousemove", this.boundMouseMove)
+    document.removeEventListener("mouseup", this.boundMouseUp)
+  }
+
+  updateVisibility() {
+    if (this.isMobile()) {
+      this.dividerTarget.style.display = "none"
+      this.chatTarget.style.width = ""
+      this.logTarget.style.width = ""
+    } else {
+      this.dividerTarget.style.display = "block"
+    }
+  }
+
+  isMobile() {
+    return window.innerWidth <= this.mobileBreakpointValue
+  }
+}

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -23,16 +23,17 @@
   </div>
 <% end %>
 
-<div data-controller="tabs" class="codex-layout">
+<div data-controller="tabs resizable-panels" class="codex-layout">
   <%= turbo_stream_from @task %>
   <div class="nav">
     <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="chat" class="tab chat-tab">Chat</button>
     <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="steps" class="tab -active">Runs</button>
   </div>
-  <div data-tabs-target="panel" data-panel-id="chat" class="chat-panel">
+  <div data-tabs-target="panel" data-resizable-panels-target="chat" data-panel-id="chat" class="chat-panel">
     <%= render "tasks/chat_panel", task: @task, runs: @task.runs.order(:created_at) %>
   </div>
-  <div data-tabs-target="panel" data-panel-id="steps" class="log-panel -active">
+  <div data-resizable-panels-target="divider" class="divider" data-action="mousedown->resizable-panels#startResize"></div>
+  <div data-tabs-target="panel" data-resizable-panels-target="log" data-panel-id="steps" class="log-panel -active">
     <% if @task.runs.any? %>
       <%= render "tasks/runs_list", runs: @runs %>
     <% else %>


### PR DESCRIPTION
## Summary
- enable adjusting chat and run panel widths via drag handle
- implement `resizable-panels` Stimulus controller
- hide handle on mobile screens

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6854da295adc832d865908419cd5e818