### PR TITLE
Fix mobile auto push button width

### DIFF
--- a/app/assets/stylesheets/auto-push.css
+++ b/app/assets/stylesheets/auto-push.css
@@ -24,3 +24,32 @@
   padding: 4px 8px;
   font-size: 14px;
 }
+
+@media (max-width: 768px) {
+  .auto-push {
+    flex-wrap: wrap;
+    gap: 12px;
+    width: 100%;
+  }
+  
+  .auto-push > .label {
+    width: 100%;
+  }
+  
+  .auto-push > .selector {
+    flex: 1;
+    min-width: 0;
+  }
+  
+  .auto-push .select {
+    width: 100%;
+  }
+  
+  .auto-push > .button {
+    flex-shrink: 0;
+  }
+  
+  .auto-push > .button[type="submit"] {
+    width: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed the save button for the auto push form being too wide on mobile devices
- Added responsive CSS for mobile viewports

## Changes
- Added media query for devices with max-width of 768px
- Made the auto-push form layout wrap on mobile with proper spacing
- Set the label to full width for better mobile layout
- Made the branch selector flexible to use available space
- Ensured the save button maintains its natural width

The save button now displays at its appropriate size on mobile instead of stretching too wide.

🤖 Generated with [Claude Code](https://claude.ai/code)