### PR TITLE
Improve run form layout

### DIFF
--- a/app/assets/stylesheets/run-form.css
+++ b/app/assets/stylesheets/run-form.css
@@ -1,5 +1,12 @@
+.run-form {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+}
+
 .run-form > .field {
-  margin-bottom: 10px;
+  flex: 1;
+  margin-bottom: 0;
 }
 
 .run-form > .field > .textarea {
@@ -17,5 +24,5 @@
 }
 
 .run-form > .actions {
-  margin-top: 10px;
+  margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- style the run form to align the Run button beside the textarea

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bundle exec brakeman --no-pager`


------
https://chatgpt.com/codex/tasks/task_e_68561405dce0832d9893eabbc440defc