### PR TITLE
Add shrimp mode

### DIFF
--- a/app/assets/stylesheets/shrimp-mode.css
+++ b/app/assets/stylesheets/shrimp-mode.css
@@ -1,0 +1,15 @@
+.shrimp {
+  position: fixed;
+  top: -2rem;
+  font-size: 2rem;
+  pointer-events: none;
+  z-index: 1000;
+  animation: shrimp-fall 1.2s linear forwards;
+}
+
+@keyframes shrimp-fall {
+  to {
+    transform: translateY(100vh) rotate(720deg);
+    opacity: 0;
+  }
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -29,6 +29,7 @@ class TasksController < ApplicationController
       cookies[:preferred_project_id] = { value: @task.project_id, expires: 1.year.from_now }
       @task.update!(started_at: Time.current)
       @task.run(params[:task][:prompt])
+      flash[:shrimp_explosion] = true
       redirect_to task_path(@task), notice: "Task was successfully launched."
     else
       if @project.present?

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -29,6 +29,6 @@ class UserSettingsController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:github_token, :ssh_key, :instructions, :git_config)
+    params.require(:user).permit(:github_token, :ssh_key, :instructions, :git_config, :shrimp_mode)
   end
 end

--- a/app/javascript/controllers/shrimp_controller.js
+++ b/app/javascript/controllers/shrimp_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { enabled: Boolean, trigger: Boolean }
+
+  connect() {
+    if (this.enabledValue && this.triggerValue) {
+      this.launch()
+    }
+  }
+
+  launch() {
+    const count = 30
+    for (let i = 0; i < count; i++) {
+      const el = document.createElement("div")
+      el.textContent = "\ud83c\udf64"
+      el.classList.add("shrimp")
+      el.style.left = Math.random() * 100 + "vw"
+      el.style.animationDelay = Math.random() * 0.5 + "s"
+      document.body.appendChild(el)
+      el.addEventListener("animationend", () => el.remove())
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/diff2html/bundles/js/diff2html-ui.min.js"></script>
   </head>
 
-  <body class="<%= controller_name %> <%= action_name %>">
+  <body class="<%= controller_name %> <%= action_name %>" data-controller="shrimp" data-shrimp-enabled-value="<%= Current.user&.shrimp_mode? %>" data-shrimp-trigger-value="<%= flash[:shrimp_explosion].present? %>">
     <%= content_for?(:nav) ? yield(:nav) : render("nav") %>
     
     <main>

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -33,6 +33,11 @@
   </div>
 
   <div>
+    <%= form.label :shrimp_mode, "Shrimp Mode" %>
+    <%= form.check_box :shrimp_mode %>
+  </div>
+
+  <div>
     <%= form.submit "Update Settings" %>
   </div>
 <% end %>

--- a/app/views/user_settings/show.html.erb
+++ b/app/views/user_settings/show.html.erb
@@ -37,6 +37,11 @@
   <% end %>
 </div>
 
+<div>
+  <strong>Shrimp Mode:</strong>
+  <%= @user.shrimp_mode? ? 'Enabled' : 'Disabled' %>
+</div>
+
 <p>
   <%= link_to 'Edit Settings', edit_user_settings_path, class: 'button' %>
 </p>

--- a/db/migrate/20250619000000_add_shrimp_mode_to_users.rb
+++ b/db/migrate/20250619000000_add_shrimp_mode_to_users.rb
@@ -1,0 +1,5 @@
+class AddShrimpModeToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :shrimp_mode, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_18_004105) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_19_000000) do
   create_table "agent_specific_settings", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.string "type", null: false
@@ -141,6 +141,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_18_004105) do
     t.text "instructions"
     t.text "ssh_key"
     t.text "git_config"
+    t.boolean "shrimp_mode", default: true, null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -37,6 +37,12 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to task_path(Task.last)
   end
 
+  test "create sets shrimp explosion flash" do
+    login @user
+    post project_tasks_url(@project), params: { task: { agent_id: @agent.id, prompt: "hi" } }
+    assert flash[:shrimp_explosion]
+  end
+
   test "show requires authentication" do
     get task_url(@task)
     assert_redirected_to new_session_path

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,10 @@ one:
   email_address: one@example.com
   password_digest: <%= password_digest %>
   role: admin
+  shrimp_mode: true
 
 two:
   email_address: two@example.com
   password_digest: <%= password_digest %>
   role: standard
+  shrimp_mode: true


### PR DESCRIPTION
## Summary
- add shrimp mode toggle to users
- show shrimp mode settings in user pages
- default shrimp mode is enabled via migration
- trigger fried shrimp animation when creating tasks
- implement shrimp Stimulus controller and styles
- test flash for shrimp explosion

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68561d5b2790832d9b69a855eeea0b4e