### PR TITLE
Implement auto-follow scrolling for chat and logs

### DIFF
--- a/app/javascript/controllers/auto_scroll_controller.js
+++ b/app/javascript/controllers/auto_scroll_controller.js
@@ -1,0 +1,50 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.scrollContainer = this.findScrollContainer()
+    this.useWindow = this.scrollContainer === window
+    this.follow = true
+    this.boundCheck = this.check.bind(this)
+    this.boundMaybe = this.maybe.bind(this)
+    this.scrollContainer.addEventListener("scroll", this.boundCheck)
+    this.observer = new MutationObserver(this.boundMaybe)
+    this.observer.observe(this.element, { childList: true, subtree: true })
+    this.scroll()
+  }
+
+  disconnect() {
+    this.scrollContainer.removeEventListener("scroll", this.boundCheck)
+    if (this.observer) this.observer.disconnect()
+  }
+
+  check() {
+    const el = this.useWindow ? document.documentElement : this.scrollContainer
+    const bottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 5
+    this.follow = bottom
+  }
+
+  maybe() {
+    if (this.follow) this.scroll()
+  }
+
+  scroll() {
+    if (this.useWindow) {
+      window.scrollTo(0, document.documentElement.scrollHeight)
+    } else {
+      this.scrollContainer.scrollTop = this.scrollContainer.scrollHeight
+    }
+  }
+
+  findScrollContainer() {
+    let el = this.element
+    while (el && el !== document.body) {
+      const overflow = getComputedStyle(el).overflowY
+      if (overflow === "auto" || overflow === "scroll") {
+        return el
+      }
+      el = el.parentElement
+    }
+    return window
+  }
+}

--- a/app/views/runs/_tabs.html.erb
+++ b/app/views/runs/_tabs.html.erb
@@ -11,7 +11,7 @@
   </div>
   <div class="content">
     <div data-tabs-target="panel" data-panel-id="steps" class="panel -active">
-      <div class="output">
+      <div class="output" data-controller="auto-scroll">
         <%= render run.steps %>
         <% if run.status == 'running' %>
           <div class="run-spinner">
@@ -22,7 +22,7 @@
       </div>
     </div>
     <div data-tabs-target="panel" data-panel-id="raw" class="panel">
-      <div class="output">
+      <div class="output" data-controller="auto-scroll">
         <% run.steps.each do |step| %>
           <div class="step-raw">
             <% begin %>
@@ -43,7 +43,7 @@
     </div>
     <% repo_states.each_with_index do |repo_state, index| %>
       <div data-tabs-target="panel" data-panel-id="diff-<%= index %>" class="panel">
-        <div class="output">
+        <div class="output" data-controller="auto-scroll">
           <%= render "runs/diff_panel", repo_state: repo_state %>
         </div>
       </div>

--- a/app/views/tasks/_chat_messages.html.erb
+++ b/app/views/tasks/_chat_messages.html.erb
@@ -1,4 +1,4 @@
-<div id="chat-messages">
+<div id="chat-messages" data-controller="auto-scroll">
   <% if runs.any? %>
     <% runs.each do |run| %>
       <%= render "runs/chat_item", run: run %>

--- a/app/views/tasks/_runs_list.html.erb
+++ b/app/views/tasks/_runs_list.html.erb
@@ -1,4 +1,4 @@
-<div id="runs-list">
+<div id="runs-list" data-controller="auto-scroll">
   <% runs.each do |run| %>
     <%= render "tasks/run", run: run %>
   <% end %>


### PR DESCRIPTION
## Summary
- add `auto-scroll` stimulus controller
- follow new entries at bottom of chat and run logs
- hook `auto-scroll` into chat and log views
- fix scroll container detection in Stimulus controller

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685619f1407c832da32022e1f707e493