### PR TITLE
Fix flash alerts stacking issue

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -72,7 +72,7 @@ class TasksController < ApplicationController
   rescue => e
     Rails.logger.error "Branch fetch error: #{e.message}"
     flash.now[:alert] = "Failed to fetch branches: #{e.message}"
-    render turbo_stream: turbo_stream.prepend("flash-messages", partial: "application/flash_messages")
+    render turbo_stream: turbo_stream.replace("flash-messages", partial: "application/flash_messages")
   end
 
   def update_auto_push
@@ -92,7 +92,7 @@ class TasksController < ApplicationController
 
       render turbo_stream: [
         turbo_stream.replace("auto_push_form", partial: "tasks/auto_push_form", locals: { task: @task }),
-        turbo_stream.prepend("flash-messages", partial: "application/flash_messages")
+        turbo_stream.replace("flash-messages", partial: "application/flash_messages")
       ]
     else
       render json: { error: @task.errors.full_messages.join(", ") }, status: :unprocessable_entity


### PR DESCRIPTION
## Summary
- Fixed flash alerts stacking on subsequent turbo stream requests
- Changed `turbo_stream.prepend` to `turbo_stream.replace` in TasksController
- Flash messages now properly override each other instead of accumulating

🤖 Generated with [Claude Code](https://claude.ai/code)