### PR TITLE
Fix flash alerts being hidden by sliding header

### DIFF
--- a/app/javascript/controllers/sliding_header_controller.js
+++ b/app/javascript/controllers/sliding_header_controller.js
@@ -73,6 +73,7 @@ export default class extends Controller {
   showHeader() {
     this.isShowing = true
     this.headerTarget.style.transform = 'translateY(0)'
+    this.dismissFlashAlerts()
   }
   
   hideHeader() {
@@ -87,5 +88,12 @@ export default class extends Controller {
     } else if (!this.isShowing) {
       this.hideHeader()
     }
+  }
+  
+  dismissFlashAlerts() {
+    const flashAlerts = document.querySelectorAll('[data-controller="alert"]')
+    flashAlerts.forEach(alert => {
+      alert.remove()
+    })
   }
 }


### PR DESCRIPTION
## Summary
- Fixed flash alerts getting covered by the sliding header on tasks#show pages
- Flash alerts now automatically dismiss when the sliding header appears
- Prevents UI overlap issues where alerts become unreadable

🤖 Generated with [Claude Code](https://claude.ai/code)