### PR TITLE
Add container request proxy with subdomain routing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "docker-api"
 gem "discard"
 gem "redcarpet"
 gem "fast-mcp"
+gem "rack-proxy"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.15)
+    rack-proxy (0.7.7)
+      rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -451,6 +453,7 @@ DEPENDENCIES
   mocha
   propshaft
   puma (>= 5.0)
+  rack-proxy
   rails (~> 8.0.2)
   redcarpet
   rubocop-rails-omakase

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -62,4 +62,8 @@ module TasksHelper
       )
     end
   end
+
+  def task_proxy_path(task, path = "/")
+    "/tasks/#{task.id}/proxy#{path}"
+  end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -66,7 +66,7 @@ module TasksHelper
   def task_proxy_path(task, path = nil)
     # Use proxy links only if CONTAINER_PROXY_LINKS is explicitly set
     use_proxy_links = ENV["CONTAINER_PROXY_LINKS"].present?
-    
+
     unless use_proxy_links
       container_info = container_status_info(task)
       if container_info.port_info.present?
@@ -76,9 +76,9 @@ module TasksHelper
         return "#" # No port available
       end
     end
-    
+
     request = controller.request
-    
+
     # Use CONTAINER_PROXY_BASE_URL if set, otherwise build from current request
     if ENV["CONTAINER_PROXY_BASE_URL"].present?
       base_url = ENV["CONTAINER_PROXY_BASE_URL"]
@@ -90,20 +90,20 @@ module TasksHelper
       host_parts.unshift("task-#{task.id}")
       uri.host = host_parts.join(".")
       base = uri.to_s
-      return path ? "#{base}#{path}" : base
+      path ? "#{base}#{path}" : base
     else
       # Build from current request
       host_parts = request.host_with_port.split(".")
-      
+
       # Replace the first part with task-{id} subdomain
       if host_parts.first.match?(/^task-\d+$/)
         host_parts[0] = "task-#{task.id}"
       else
         host_parts.unshift("task-#{task.id}")
       end
-      
+
       base = "#{request.protocol}#{host_parts.join(".")}"
-      return path ? "#{base}#{path}" : base
+      path ? "#{base}#{path}" : base
     end
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -64,6 +64,16 @@ module TasksHelper
   end
 
   def task_proxy_path(task, path = "/")
-    "/tasks/#{task.id}/proxy#{path}"
+    request = controller.request
+    host_parts = request.host_with_port.split(".")
+    
+    # Replace the first part with task-{id} subdomain
+    if host_parts.first.match?(/^task-\d+$/)
+      host_parts[0] = "task-#{task.id}"
+    else
+      host_parts.unshift("task-#{task.id}")
+    end
+    
+    "#{request.protocol}#{host_parts.join(".")}#{path}"
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -64,6 +64,16 @@ module TasksHelper
   end
 
   def task_proxy_path(task, path = "/")
+    # If CONTAINER_DIRECT_LINKS is set, bypass proxy and use direct localhost URLs
+    if ENV["CONTAINER_DIRECT_LINKS"].present?
+      container_info = container_status_info(task)
+      if container_info.port_info.present?
+        return "http://localhost:#{container_info.port_info}#{path}"
+      else
+        return "#" # No port available
+      end
+    end
+    
     request = controller.request
     
     # Use CONTAINER_PROXY_BASE_URL if set, otherwise build from current request

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -63,14 +63,15 @@ module TasksHelper
     end
   end
 
-  def task_proxy_path(task, path = "/")
+  def task_proxy_path(task, path = nil)
     # Use proxy links only if CONTAINER_PROXY_LINKS is explicitly set
     use_proxy_links = ENV["CONTAINER_PROXY_LINKS"].present?
     
     unless use_proxy_links
       container_info = container_status_info(task)
       if container_info.port_info.present?
-        return "http://localhost:#{container_info.port_info}#{path}"
+        base = "http://localhost:#{container_info.port_info}"
+        return path ? "#{base}#{path}" : base
       else
         return "#" # No port available
       end
@@ -88,7 +89,8 @@ module TasksHelper
       host_parts = uri.host.split(".")
       host_parts.unshift("task-#{task.id}")
       uri.host = host_parts.join(".")
-      "#{uri}#{path}"
+      base = uri.to_s
+      return path ? "#{base}#{path}" : base
     else
       # Build from current request
       host_parts = request.host_with_port.split(".")
@@ -100,7 +102,8 @@ module TasksHelper
         host_parts.unshift("task-#{task.id}")
       end
       
-      "#{request.protocol}#{host_parts.join(".")}#{path}"
+      base = "#{request.protocol}#{host_parts.join(".")}"
+      return path ? "#{base}#{path}" : base
     end
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -64,12 +64,10 @@ module TasksHelper
   end
 
   def task_proxy_path(task, path = "/")
-    # Default to direct links unless explicitly disabled by setting CONTAINER_DIRECT_LINKS=0 or false
-    use_direct_links = ENV["CONTAINER_DIRECT_LINKS"].nil? || 
-                       ENV["CONTAINER_DIRECT_LINKS"].present? && 
-                       !ENV["CONTAINER_DIRECT_LINKS"].match?(/^(0|false|no)$/i)
+    # Use proxy links only if CONTAINER_PROXY_LINKS is explicitly set
+    use_proxy_links = ENV["CONTAINER_PROXY_LINKS"].present?
     
-    if use_direct_links
+    unless use_proxy_links
       container_info = container_status_info(task)
       if container_info.port_info.present?
         return "http://localhost:#{container_info.port_info}#{path}"

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -64,8 +64,12 @@ module TasksHelper
   end
 
   def task_proxy_path(task, path = "/")
-    # If CONTAINER_DIRECT_LINKS is set, bypass proxy and use direct localhost URLs
-    if ENV["CONTAINER_DIRECT_LINKS"].present?
+    # Default to direct links unless explicitly disabled by setting CONTAINER_DIRECT_LINKS=0 or false
+    use_direct_links = ENV["CONTAINER_DIRECT_LINKS"].nil? || 
+                       ENV["CONTAINER_DIRECT_LINKS"].present? && 
+                       !ENV["CONTAINER_DIRECT_LINKS"].match?(/^(0|false|no)$/i)
+    
+    if use_direct_links
       container_info = container_status_info(task)
       if container_info.port_info.present?
         return "http://localhost:#{container_info.port_info}#{path}"

--- a/app/views/tasks/_docker_controls.html.erb
+++ b/app/views/tasks/_docker_controls.html.erb
@@ -24,7 +24,8 @@
       <span class="container-status">
         Container: <%= task.container_name %> (<%= container_info.status %>)
         <% if container_info.port_info %>
-          | Port: <%= link_to "localhost:#{container_info.port_info}", task_proxy_path(task), target: "_blank" %>
+          <% proxy_url = task_proxy_path(task) %>
+          | Port: <%= link_to proxy_url.sub(/^https?:\/\//, ''), proxy_url, target: "_blank" %>
         <% elsif task.project.dev_container_port.present? %>
           | Port: <%= task.project.dev_container_port %> (not mapped)
         <% end %>

--- a/app/views/tasks/_docker_controls.html.erb
+++ b/app/views/tasks/_docker_controls.html.erb
@@ -24,7 +24,7 @@
       <span class="container-status">
         Container: <%= task.container_name %> (<%= container_info.status %>)
         <% if container_info.port_info %>
-          | Port: <%= link_to "localhost:#{container_info.port_info}", "http://localhost:#{container_info.port_info}", target: "_blank" %>
+          | Port: <%= link_to "localhost:#{container_info.port_info}", task_proxy_path(task), target: "_blank" %>
         <% elsif task.project.dev_container_port.present? %>
           | Port: <%= task.project.dev_container_port %> (not mapped)
         <% end %>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -44,6 +44,10 @@ env:
     
     # Docker daemon URL for agent containers
     DOCKER_URL: tcp://172.18.0.1:2375
+    
+    # Enable proxy links and target containers directly when running in container
+    CONTAINER_PROXY_LINKS: "1"
+    CONTAINER_PROXY_TARGET_CONTAINERS: "1"
 
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,5 @@ Rails.application.configure do
 
   # Allow Docker containers to connect
   config.hosts << "host.docker.internal"
+  config.hosts << /^task-\d+\./
 end

--- a/config/initializers/container_proxy.rb
+++ b/config/initializers/container_proxy.rb
@@ -22,7 +22,6 @@ class ContainerProxy
   end
 
   def handle_proxy_request(env)
-    request = Rack::Request.new(env)
     host = env["HTTP_HOST"] || ""
 
     if (match = host.match(/^task-(\d+)\./))

--- a/config/initializers/container_proxy.rb
+++ b/config/initializers/container_proxy.rb
@@ -1,71 +1,75 @@
 require "rack-proxy"
 
-class ContainerProxy < Rack::Proxy
-  def initialize(app = nil, opts = {})
+class ContainerProxy
+  def initialize(app)
     @app = app
-    super(opts.merge(backend: "http://localhost", streaming: false))
+    @proxy = Rack::Proxy.new(streaming: false)
   end
 
   def call(env)
     if proxy_request?(env)
-      perform_request(env)
-    else
-      @app.call(env) if @app
-    end
-  end
-
-  def perform_request(env)
-    request = Rack::Request.new(env)
-
-    if (match = request.path.match(%r{^/tasks/(\d+)/proxy(/.*)?$}))
-      task_id = match[1]
-      path = match[2] || "/"
-
-      task = Task.find_by(id: task_id)
-
-      if task && task.container_id.present?
-        container = Docker::Container.get(task.container_id)
-        container_info = container.json
-
-        if ENV["CONTAINER_PROXY_MODE"].present?
-          host = container_info["NetworkSettings"]["IPAddress"]
-        else
-          host = "localhost"
-        end
-
-        port = task.project.dev_container_port
-
-        if host.present? && port.present?
-          env["PATH_INFO"] = path
-          env["REQUEST_PATH"] = path
-          env["REQUEST_URI"] = path
-
-          @backend = URI("http://#{host}:#{port}")
-          @streaming = false
-
-          super(env)
-        else
-          [ 503, { "Content-Type" => "text/plain" }, [ "Container not accessible" ] ]
-        end
-      else
-        [ 404, { "Content-Type" => "text/plain" }, [ "Task or container not found" ] ]
-      end
+      handle_proxy_request(env)
     else
       @app.call(env)
     end
-  rescue Docker::Error::NotFoundError
-    [ 404, { "Content-Type" => "text/plain" }, [ "Container not found" ] ]
-  rescue => e
-    Rails.logger.error "Container proxy error: #{e.message}"
-    [ 500, { "Content-Type" => "text/plain" }, [ "Proxy error" ] ]
   end
+
+  private
 
   def proxy_request?(env)
     env["PATH_INFO"].start_with?("/tasks/") && env["PATH_INFO"].include?("/proxy")
   end
 
-  def rewrite_env(env)
-    env
+  def handle_proxy_request(env)
+    request = Rack::Request.new(env)
+    
+    if (match = request.path.match(%r{^/tasks/(\d+)/proxy(/.*)?$}))
+      task_id = match[1]
+      path = match[2] || "/"
+      
+      task = Task.find_by(id: task_id)
+      
+      if task && task.container_id.present?
+        begin
+          container = Docker::Container.get(task.container_id)
+          container_info = container.json
+          
+          if ENV["CONTAINER_PROXY_MODE"].present?
+            host = container_info["NetworkSettings"]["IPAddress"]
+          else
+            host = "localhost"
+          end
+          
+          port = task.project.dev_container_port
+          
+          if host.present? && port.present?
+            # Rewrite the request for the proxy
+            env["PATH_INFO"] = path
+            env["REQUEST_PATH"] = path
+            env["REQUEST_URI"] = "http://#{host}:#{port}#{path}"
+            env["HTTP_HOST"] = "#{host}:#{port}"
+            env["SERVER_NAME"] = host
+            env["SERVER_PORT"] = port.to_s
+            
+            # Create a new proxy instance with the backend
+            proxy = Rack::Proxy.new(backend: "http://#{host}:#{port}", streaming: false)
+            proxy.call(env)
+          else
+            [ 503, { "Content-Type" => "text/plain" }, [ "Container not accessible" ] ]
+          end
+        rescue Docker::Error::NotFoundError
+          [ 404, { "Content-Type" => "text/plain" }, [ "Container not found" ] ]
+        end
+      else
+        [ 404, { "Content-Type" => "text/plain" }, [ "Task or container not found" ] ]
+      end
+    else
+      [ 404, { "Content-Type" => "text/plain" }, [ "Invalid proxy path" ] ]
+    end
+  rescue => e
+    Rails.logger.error "Container proxy error: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    [ 500, { "Content-Type" => "text/plain" }, [ "Proxy error: #{e.message}" ] ]
   end
 end
 

--- a/config/initializers/container_proxy.rb
+++ b/config/initializers/container_proxy.rb
@@ -36,12 +36,12 @@ class ContainerProxy
           container = Docker::Container.get(task.container_id)
           container_info = container.json
           
-          if ENV["CONTAINER_PROXY_MODE"].present?
-            # When running inside a container, use the container's internal IP and port
+          if ENV["CONTAINER_PROXY_TARGET_CONTAINERS"].present?
+            # Proxy directly to container's internal IP and port
             host = container_info["NetworkSettings"]["IPAddress"]
             port = task.project.dev_container_port
           else
-            # When running on host, use localhost and the mapped host port
+            # Proxy to localhost and the mapped host port (default)
             host = "localhost"
             port = nil
             

--- a/config/initializers/container_proxy.rb
+++ b/config/initializers/container_proxy.rb
@@ -1,0 +1,72 @@
+require "rack-proxy"
+
+class ContainerProxy < Rack::Proxy
+  def initialize(app = nil, opts = {})
+    @app = app
+    super(opts.merge(backend: "http://localhost", streaming: false))
+  end
+
+  def call(env)
+    if proxy_request?(env)
+      perform_request(env)
+    else
+      @app.call(env) if @app
+    end
+  end
+
+  def perform_request(env)
+    request = Rack::Request.new(env)
+
+    if (match = request.path.match(%r{^/tasks/(\d+)/proxy(/.*)?$}))
+      task_id = match[1]
+      path = match[2] || "/"
+
+      task = Task.find_by(id: task_id)
+
+      if task && task.container_id.present?
+        container = Docker::Container.get(task.container_id)
+        container_info = container.json
+
+        if ENV["CONTAINER_PROXY_MODE"].present?
+          host = container_info["NetworkSettings"]["IPAddress"]
+        else
+          host = "localhost"
+        end
+
+        port = task.project.dev_container_port
+
+        if host.present? && port.present?
+          env["PATH_INFO"] = path
+          env["REQUEST_PATH"] = path
+          env["REQUEST_URI"] = path
+
+          @backend = URI("http://#{host}:#{port}")
+          @streaming = false
+
+          super(env)
+        else
+          [ 503, { "Content-Type" => "text/plain" }, [ "Container not accessible" ] ]
+        end
+      else
+        [ 404, { "Content-Type" => "text/plain" }, [ "Task or container not found" ] ]
+      end
+    else
+      @app.call(env)
+    end
+  rescue Docker::Error::NotFoundError
+    [ 404, { "Content-Type" => "text/plain" }, [ "Container not found" ] ]
+  rescue => e
+    Rails.logger.error "Container proxy error: #{e.message}"
+    [ 500, { "Content-Type" => "text/plain" }, [ "Proxy error" ] ]
+  end
+
+  def proxy_request?(env)
+    env["PATH_INFO"].start_with?("/tasks/") && env["PATH_INFO"].include?("/proxy")
+  end
+
+  def rewrite_env(env)
+    env
+  end
+end
+
+Rails.application.config.middleware.use ContainerProxy unless Rails.env.test?

--- a/hosts_entries.txt
+++ b/hosts_entries.txt
@@ -1,5 +1,0 @@
-# Task subdomains for proxy
-127.0.0.1 task-1.localhost task-2.localhost task-3.localhost task-4.localhost task-5.localhost
-127.0.0.1 task-6.localhost task-7.localhost task-8.localhost task-9.localhost task-10.localhost
-127.0.0.1 task-11.localhost task-12.localhost task-13.localhost task-14.localhost task-15.localhost
-127.0.0.1 task-16.localhost task-17.localhost task-18.localhost task-19.localhost task-20.localhost

--- a/hosts_entries.txt
+++ b/hosts_entries.txt
@@ -1,0 +1,5 @@
+# Task subdomains for proxy
+127.0.0.1 task-1.localhost task-2.localhost task-3.localhost task-4.localhost task-5.localhost
+127.0.0.1 task-6.localhost task-7.localhost task-8.localhost task-9.localhost task-10.localhost
+127.0.0.1 task-11.localhost task-12.localhost task-13.localhost task-14.localhost task-15.localhost
+127.0.0.1 task-16.localhost task-17.localhost task-18.localhost task-19.localhost task-20.localhost


### PR DESCRIPTION
## Summary
- Added rack-proxy gem to enable request proxying to Docker containers
- Implemented ContainerProxy middleware that intercepts task-*.* subdomain requests
- Added environment variables to control proxy behavior:
  - `CONTAINER_PROXY_LINKS`: Enable subdomain-based proxy links in UI
  - `CONTAINER_PROXY_TARGET_CONTAINERS`: Target container IPs directly instead of localhost with Docker-mapped ports
  - `CONTAINER_PROXY_BASE_URL`: Override base domain for proxy links
- Updated task_proxy_path helper to generate appropriate URLs based on configuration
- Configured Kamal deployment with proxy settings enabled

This allows accessing container services through subdomain-based routing (e.g., task-1.domain.com) which preserves relative URLs in proxied applications.