### PR TITLE
Add subtle nav pull tab indicator for tasks#show page

### DIFF
--- a/app/assets/stylesheets/nav-pull-tab.css
+++ b/app/assets/stylesheets/nav-pull-tab.css
@@ -1,0 +1,38 @@
+.nav-pull-tab {
+  position: absolute;
+  bottom: -19px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80px;
+  height: 24px;
+  background-color: var(--bg);
+  border-radius: 0 0 10px 10px;
+  cursor: pointer;
+  z-index: 999;
+  transition: height 0.15s ease-in-out;
+  box-shadow: 0 6px 8px -2px rgba(0, 0, 0, 0.15);
+}
+
+.nav-pull-tab::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 6px;
+  transform: translateX(-50%);
+  width: 30px;
+  height: 3px;
+  background-color: var(--text-light);
+  border-radius: 2px;
+  opacity: 0.4;
+}
+
+.nav-pull-tab:hover {
+  height: 29px;
+  box-shadow: 0 6px 12px -2px rgba(0, 0, 0, 0.2);
+}
+
+@media (max-width: 768px) {
+  .nav-pull-tab {
+    display: none;
+  }
+}

--- a/app/javascript/controllers/sliding_header_controller.js
+++ b/app/javascript/controllers/sliding_header_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["header"]
+  static targets = ["header", "pullTab"]
   static values = { 
     slideDistance: { type: Number, default: 60 },
     mobileBreakpoint: { type: Number, default: 768 }

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -29,6 +29,7 @@
           <%= render "tasks/docker_controls", task: @task %>
         <% end %>
       </div>
+      <div class="nav-pull-tab" data-sliding-header-target="pullTab" data-action="click->sliding-header#showHeader"></div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
## Summary
- Added a subtle pull tab indicator that shows on desktop when viewing tasks
- The tab provides a visual hint that there's a navigation bar above the viewport
- Clicking the tab reveals the hidden navigation

## Changes
- Created new CSS file `nav-pull-tab.css` with styling for the pull tab
- Modified `tasks/show.html.erb` to include the pull tab element
- Updated `sliding_header_controller.js` to support the pull tab target

## Design Details
- White background matching the nav bar
- Always visible (doesn't fade in/out)
- Moves seamlessly with the header when sliding
- Drop shadow for depth
- Subtle hover effect that slightly expands the tab
- Desktop-only feature (hidden on screens < 768px)