### PR TITLE
Fix production proxy URLs by setting CONTAINER_PROXY_BASE_URL

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -48,6 +48,7 @@ env:
     # Enable proxy links and target containers directly when running in container
     CONTAINER_PROXY_LINKS: "1"
     CONTAINER_PROXY_TARGET_CONTAINERS: "1"
+    CONTAINER_PROXY_BASE_URL: "summoncircle.net"
 
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3


### PR DESCRIPTION
## Summary
- Added `CONTAINER_PROXY_BASE_URL: "summoncircle.net"` to Kamal deployment config
- This fixes the issue where proxy URLs were showing as `task-66.example.org` in production
- Without this setting, the proxy helper tries to build URLs from the current request, which can return unexpected values behind proxies/load balancers