### PR TITLE
Fix git command not found error in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips sqlite3 && \
+    apt-get install --no-install-recommends -y curl git libjemalloc2 libvips sqlite3 && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment


### PR DESCRIPTION
## Summary
- Added git package to production Docker image to fix "No such file or directory - git" error
- The ProjectBranchesController executes git commands to fetch remote branches
- Git was only available in the build stage but not in the final production image

This fixes the 422 error when loading branches on the projects/tasks#new page.

🤖 Generated with [Claude Code](https://claude.ai/code)