### PR TITLE
Fix task title inline editing layout issue

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,5 @@
 class TasksController < ApplicationController
+  layout "application"
   before_action :set_project
   before_action :set_task, only: [ :show, :edit, :update, :destroy, :branches, :update_auto_push ]
 
@@ -52,10 +53,7 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_update_params)
-      respond_to do |format|
-        format.html { redirect_to @task, notice: "Task was successfully updated." }
-        format.turbo_stream { render turbo_stream: turbo_stream.replace("task_#{@task.id}_description", partial: "tasks/description", locals: { task: @task }) }
-      end
+      redirect_to @task, notice: "Task was successfully updated."
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -52,7 +52,10 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_update_params)
-      redirect_to @task, notice: "Task was successfully updated."
+      respond_to do |format|
+        format.html { redirect_to @task, notice: "Task was successfully updated." }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("task_#{@task.id}_description", partial: "tasks/description", locals: { task: @task }) }
+      end
     else
       render :edit, status: :unprocessable_entity
     end


### PR DESCRIPTION
## Summary
- Fixed issue where editing task description inline caused navigation to disappear
- Added explicit layout declaration to TasksController to ensure layout renders for Turbo frame requests

## The Problem
When clicking on a task description to edit it inline, the form submission was handled by Turbo frames. By default, Turbo frame requests don't render the application layout, which caused the navigation and other layout elements to disappear after saving.

## The Solution
Added `layout "application"` to the TasksController to explicitly ensure the layout is always rendered, even for Turbo frame requests.