### PR TITLE
Filter out detached HEAD branches from autopush branch list

### DIFF
--- a/app/models/concerns/git_operations.rb
+++ b/app/models/concerns/git_operations.rb
@@ -93,7 +93,7 @@ module GitOperations
         line.strip.sub(/^\*\s*/, "")
       end.reject(&:blank?).reject do |branch|
         # Filter out detached HEAD branches
-        branch.match(/^\(HEAD detached at [a-f0-9]+\)$/)
+        branch.match(/^\(HEAD detached at [a-fA-F0-9]+\)$/)
       end
 
       branches.presence || []

--- a/app/models/concerns/git_operations.rb
+++ b/app/models/concerns/git_operations.rb
@@ -91,7 +91,10 @@ module GitOperations
       branches = logs.lines.map do |line|
         # Remove the * for current branch and any whitespace
         line.strip.sub(/^\*\s*/, "")
-      end.reject(&:blank?)
+      end.reject(&:blank?).reject do |branch|
+        # Filter out detached HEAD branches
+        branch.match(/^\(HEAD detached at [a-f0-9]+\)$/)
+      end
 
       branches.presence || []
     rescue => e


### PR DESCRIPTION
## Summary
- Filter out detached HEAD entries like "(HEAD detached at 7aae1c2)" from the autopush branch dropdown
- Add regex check in fetch_branches method to reject detached HEAD branch names

This prevents confusing detached HEAD entries from appearing in the branch selection dropdown for autopush functionality.