### PR TITLE
Fix HTML entity escaping in diff display

### DIFF
--- a/app/views/runs/_diff_panel.html.erb
+++ b/app/views/runs/_diff_panel.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="diff" 
-     data-diff-uncommitted-diff-value="<%= repo_state.uncommitted_diff.gsub('"', '&quot;') %>"
-     data-diff-target-branch-diff-value="<%= repo_state.target_branch_diff.to_s.gsub('"', '&quot;') %>"
+     data-diff-uncommitted-diff-value="<%= html_escape(repo_state.uncommitted_diff) %>"
+     data-diff-target-branch-diff-value="<%= html_escape(repo_state.target_branch_diff.to_s) %>"
      data-diff-has-target-branch-value="<%= repo_state.target_branch_diff.present? %>">
   <div class="diff-controls">
     <% if repo_state.target_branch_diff.present? %>


### PR DESCRIPTION
## Summary
- Replace manual quote escaping with Rails' `html_escape` helper in diff panel view
- Fixes double-escaping issues when git diffs contain HTML entities like `<`, `>`, and `&`
- Ensures proper display of all special characters in diff output

## What was happening
The diff content was being escaped manually with `.gsub('"', '&quot;')` which only handled quotes but not other HTML entities. This caused characters like `<`, `>`, and `&` in the git diff to be displayed as their HTML entity codes instead of the actual characters.

## The fix
Using Rails' built-in `html_escape` helper properly escapes all HTML entities for safe inclusion in HTML attributes, preventing both XSS vulnerabilities and display issues.