### PR TITLE
Cancel running containers when starting new runs

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -11,6 +11,7 @@ class Run < ApplicationRecord
 
   attr_accessor :skip_agent
 
+  before_create :cancel_running_runs
   after_create :enqueue_job, unless: :skip_agent
   after_update_commit :broadcast_update
   after_create_commit :broadcast_chat_append
@@ -37,6 +38,7 @@ class Run < ApplicationRecord
       end
 
       container = create_container
+      update!(container_id: container.id)
       container.start
       setup_container_files(container)
 
@@ -55,7 +57,7 @@ class Run < ApplicationRecord
       steps.create!(raw_response: error_message, type: "Step::Error", content: error_message)
       failed!
     ensure
-      update!(completed_at: Time.current)
+      update!(completed_at: Time.current, container_id: nil)
       save!
       container&.delete(force: true) if defined?(container)
     end
@@ -261,5 +263,32 @@ class Run < ApplicationRecord
 
   def enqueue_job
     RunJob.perform_later(id)
+  end
+
+  def cancel_running_runs
+    task.runs.running.where.not(container_id: nil).find_each do |run|
+      run.stop_container
+    end
+  end
+
+  def stop_container
+    return unless container_id.present?
+
+    begin
+      container = Docker::Container.get(container_id)
+      container.stop
+
+      steps.create!(
+        raw_response: "Run cancelled",
+        type: "Step::System",
+        content: "This run was cancelled because a new run was started for the same task."
+      )
+
+      failed!
+    rescue Docker::Error::NotFoundError
+      Rails.logger.info "Container #{container_id} not found, may have already been stopped"
+    rescue => e
+      Rails.logger.error "Error stopping container #{container_id}: #{e.message}"
+    end
   end
 end

--- a/db/migrate/20250624013344_add_container_id_to_runs.rb
+++ b/db/migrate/20250624013344_add_container_id_to_runs.rb
@@ -1,0 +1,5 @@
+class AddContainerIdToRuns < ActiveRecord::Migration[8.0]
+  def change
+    add_column :runs, :container_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,13 +78,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_24_013344) do
   end
 
   create_table "secrets", force: :cascade do |t|
-    t.integer "project_id", null: false
     t.string "key", null: false
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["project_id", "key"], name: "index_secrets_on_project_id_and_key", unique: true
-    t.index ["project_id"], name: "index_secrets_on_project_id"
+    t.string "secretable_type", null: false
+    t.integer "secretable_id", null: false
+    t.index ["secretable_type", "secretable_id", "key"], name: "index_secrets_on_secretable_and_key", unique: true
+    t.index ["secretable_type", "secretable_id"], name: "index_secrets_on_secretable_type_and_secretable_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -181,7 +182,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_24_013344) do
   add_foreign_key "agent_specific_settings", "agents"
   add_foreign_key "repo_states", "steps"
   add_foreign_key "runs", "tasks"
-  add_foreign_key "secrets", "projects"
   add_foreign_key "sessions", "users"
   add_foreign_key "steps", "runs"
   add_foreign_key "tasks", "agents"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_22_234155) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_24_013344) do
   create_table "agent_specific_settings", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.string "type", null: false
@@ -73,6 +73,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_22_234155) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "container_id"
     t.index ["task_id"], name: "index_runs_on_task_id"
   end
 

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -577,6 +577,7 @@ class RunTest < ActiveSupport::TestCase
 
   def mock_container_with_output(output)
     mock_container = mock("container")
+    mock_container.expects(:id).returns("test-container-id-123")
     mock_container.expects(:start)
     mock_container.expects(:wait).returns({ "StatusCode" => 0 })
     mock_container.expects(:logs).with(stdout: true, stderr: true).returns(DOCKER_LOG_HEADER + output)


### PR DESCRIPTION
## Summary
- Add ability to automatically cancel running containers when a new run is started for the same task
- Containers now receive a SIGTERM signal before being stopped gracefully
- No need for a separate destroy endpoint - cancellation happens automatically in the model

## Implementation Details
- Added `container_id` field to runs table to track Docker container IDs
- Store container ID when container is created and clear it when destroyed
- Added `before_create` callback to cancel any running runs for the same task
- Implemented `stop_container` method that sends SIGTERM to Docker containers
- Added system step to cancelled runs explaining why they were stopped

## Test plan
- [x] Run tests - all passing
- [x] Run linter - no offenses
- [x] Run security analysis - no issues
- [x] Manual testing - verified containers are stopped when new runs start

🤖 Generated with [Claude Code](https://claude.ai/code)