### PR TITLE
Add styling for LS, WebFetch, and WebSearch tools

### DIFF
--- a/app/assets/stylesheets/ls-tool.css
+++ b/app/assets/stylesheets/ls-tool.css
@@ -1,0 +1,54 @@
+.ls-tool {
+  background-color: var(--bg-folder, #f7f3e9);
+  color: var(--text-folder, #333);
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin: 0.5rem 0;
+  border-left: 3px solid var(--border-folder, #d4a574);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ls-tool {
+    background-color: var(--bg-folder-dark, #2a2520);
+    color: var(--text-folder-dark, #e6e6e6);
+    border-left: 3px solid var(--border-folder-dark, #8b6f47);
+  }
+}
+
+.ls-tool .tool-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--label-folder, #8b6f47);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ls-tool .tool-header {
+    color: var(--label-folder-dark, #d4a574);
+  }
+}
+
+.ls-tool .tool-icon {
+  font-size: 1.1rem;
+}
+
+.ls-tool .tool-path {
+  background-color: var(--bg-content, #fff);
+  padding: 0.5rem;
+  border-radius: 3px;
+  overflow-x: auto;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+  font-size: 0.8125rem;
+  margin-bottom: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ls-tool .tool-path {
+    background-color: var(--bg-content-dark, #1a1814);
+  }
+}

--- a/app/assets/stylesheets/ls-tool.css
+++ b/app/assets/stylesheets/ls-tool.css
@@ -1,54 +1,39 @@
 .ls-tool {
-  background-color: var(--bg-folder, #f7f3e9);
-  color: var(--text-folder, #333);
+  background-color: var(--bg-ls-tool);
+  color: var(--text);
   padding: 0.75rem 1rem;
   border-radius: 4px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 0.875rem;
   line-height: 1.6;
   margin: 0.5rem 0;
-  border-left: 3px solid var(--border-folder, #d4a574);
+  border-left: 3px solid var(--border-ls);
 }
 
-@media (prefers-color-scheme: dark) {
-  .ls-tool {
-    background-color: var(--bg-folder-dark, #2a2520);
-    color: var(--text-folder-dark, #e6e6e6);
-    border-left: 3px solid var(--border-folder-dark, #8b6f47);
-  }
-}
-
-.ls-tool .tool-header {
+.ls-tool > .tool-header {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--label-folder, #8b6f47);
+  background-color: var(--bg-ls-header);
+  margin: -0.75rem -1rem 0.75rem -1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 4px 4px 0 0;
 }
 
-@media (prefers-color-scheme: dark) {
-  .ls-tool .tool-header {
-    color: var(--label-folder-dark, #d4a574);
-  }
-}
-
-.ls-tool .tool-icon {
+.ls-tool > .tool-header > .tool-icon {
   font-size: 1.1rem;
+  color: var(--color-ls-icon);
 }
 
-.ls-tool .tool-path {
-  background-color: var(--bg-content, #fff);
-  padding: 0.5rem;
-  border-radius: 3px;
-  overflow-x: auto;
+.ls-tool > .tool-header > .tool-label {
+  font-weight: 600;
+  color: var(--color-ls-icon);
+}
+
+.ls-tool > .tool-header > .file-path {
+  margin-left: auto;
   font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
   font-size: 0.8125rem;
-  margin-bottom: 0.5rem;
-}
-
-@media (prefers-color-scheme: dark) {
-  .ls-tool .tool-path {
-    background-color: var(--bg-content-dark, #1a1814);
-  }
+  color: var(--text-secondary);
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -63,6 +63,26 @@
   --bg-grep-tool: #fff0f5;
   --bg-grep-header: #ffe5ed;
   --color-grep-icon: #ec4899;
+  
+  /* LS tool colors */
+  --bg-ls-tool: #f7f3e9;
+  --bg-ls-header: #ebe5d1;
+  --color-ls-icon: #8b6f47;
+  --border-ls: #d4a574;
+  
+  /* WebFetch tool colors */
+  --bg-webfetch-tool: #e8f4fd;
+  --bg-webfetch-header: #d1e9fc;
+  --color-webfetch-icon: #1565c0;
+  --border-webfetch: #2196f3;
+  --color-webfetch-url: #1565c0;
+  --bg-webfetch-prompt: #f5f5f5;
+  
+  /* WebSearch tool colors */
+  --bg-websearch-tool: #f3e5f5;
+  --bg-websearch-header: #e8d4ec;
+  --color-websearch-icon: #6a1b9a;
+  --border-websearch: #9c27b0;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -122,5 +142,25 @@
     --bg-grep-tool: #2e0f1a;
     --bg-grep-header: #4e1f2d;
     --color-grep-icon: #f472b6;
+    
+    /* LS tool colors - dark */
+    --bg-ls-tool: #2a2520;
+    --bg-ls-header: #3d3328;
+    --color-ls-icon: #d4a574;
+    --border-ls: #8b6f47;
+    
+    /* WebFetch tool colors - dark */
+    --bg-webfetch-tool: #1a2332;
+    --bg-webfetch-header: #243347;
+    --color-webfetch-icon: #64b5f6;
+    --border-webfetch: #1976d2;
+    --color-webfetch-url: #64b5f6;
+    --bg-webfetch-prompt: #1a1a1a;
+    
+    /* WebSearch tool colors - dark */
+    --bg-websearch-tool: #2e1a33;
+    --bg-websearch-header: #3d2444;
+    --color-websearch-icon: #ba68c8;
+    --border-websearch: #7b1fa2;
   }
 }

--- a/app/assets/stylesheets/webfetch-tool.css
+++ b/app/assets/stylesheets/webfetch-tool.css
@@ -1,0 +1,72 @@
+.webfetch-tool {
+  background-color: var(--bg-web, #e8f4fd);
+  color: var(--text-web, #1a1a1a);
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin: 0.5rem 0;
+  border-left: 3px solid var(--border-web, #2196f3);
+}
+
+@media (prefers-color-scheme: dark) {
+  .webfetch-tool {
+    background-color: var(--bg-web-dark, #1a2332);
+    color: var(--text-web-dark, #e6e6e6);
+    border-left: 3px solid var(--border-web-dark, #1976d2);
+  }
+}
+
+.webfetch-tool .tool-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--label-web, #1565c0);
+}
+
+@media (prefers-color-scheme: dark) {
+  .webfetch-tool .tool-header {
+    color: var(--label-web-dark, #64b5f6);
+  }
+}
+
+.webfetch-tool .tool-icon {
+  font-size: 1.1rem;
+}
+
+.webfetch-tool .tool-url {
+  background-color: var(--bg-content, #fff);
+  padding: 0.5rem;
+  border-radius: 3px;
+  overflow-x: auto;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+  font-size: 0.8125rem;
+  margin-bottom: 0.5rem;
+  color: var(--url-color, #1565c0);
+  text-decoration: underline;
+}
+
+@media (prefers-color-scheme: dark) {
+  .webfetch-tool .tool-url {
+    background-color: var(--bg-content-dark, #0d1219);
+    color: var(--url-color-dark, #64b5f6);
+  }
+}
+
+.webfetch-tool .tool-prompt {
+  background-color: var(--bg-prompt, #f5f5f5);
+  padding: 0.5rem;
+  border-radius: 3px;
+  font-style: italic;
+  font-size: 0.8125rem;
+  margin-bottom: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .webfetch-tool .tool-prompt {
+    background-color: var(--bg-prompt-dark, #1a1a1a);
+  }
+}

--- a/app/assets/stylesheets/webfetch-tool.css
+++ b/app/assets/stylesheets/webfetch-tool.css
@@ -1,72 +1,49 @@
 .webfetch-tool {
-  background-color: var(--bg-web, #e8f4fd);
-  color: var(--text-web, #1a1a1a);
+  background-color: var(--bg-webfetch-tool);
+  color: var(--text);
   padding: 0.75rem 1rem;
   border-radius: 4px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 0.875rem;
   line-height: 1.6;
   margin: 0.5rem 0;
-  border-left: 3px solid var(--border-web, #2196f3);
+  border-left: 3px solid var(--border-webfetch);
 }
 
-@media (prefers-color-scheme: dark) {
-  .webfetch-tool {
-    background-color: var(--bg-web-dark, #1a2332);
-    color: var(--text-web-dark, #e6e6e6);
-    border-left: 3px solid var(--border-web-dark, #1976d2);
-  }
-}
-
-.webfetch-tool .tool-header {
+.webfetch-tool > .tool-header {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--label-web, #1565c0);
+  background-color: var(--bg-webfetch-header);
+  margin: -0.75rem -1rem 0.75rem -1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 4px 4px 0 0;
 }
 
-@media (prefers-color-scheme: dark) {
-  .webfetch-tool .tool-header {
-    color: var(--label-web-dark, #64b5f6);
-  }
-}
-
-.webfetch-tool .tool-icon {
+.webfetch-tool > .tool-header > .tool-icon {
   font-size: 1.1rem;
+  color: var(--color-webfetch-icon);
 }
 
-.webfetch-tool .tool-url {
-  background-color: var(--bg-content, #fff);
-  padding: 0.5rem;
-  border-radius: 3px;
-  overflow-x: auto;
+.webfetch-tool > .tool-header > .tool-label {
+  font-weight: 600;
+  color: var(--color-webfetch-icon);
+}
+
+.webfetch-tool > .tool-header > .url {
+  margin-left: auto;
   font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
   font-size: 0.8125rem;
-  margin-bottom: 0.5rem;
-  color: var(--url-color, #1565c0);
+  color: var(--color-webfetch-url);
   text-decoration: underline;
 }
 
-@media (prefers-color-scheme: dark) {
-  .webfetch-tool .tool-url {
-    background-color: var(--bg-content-dark, #0d1219);
-    color: var(--url-color-dark, #64b5f6);
-  }
-}
-
-.webfetch-tool .tool-prompt {
-  background-color: var(--bg-prompt, #f5f5f5);
+.webfetch-tool > .prompt {
+  background-color: var(--bg-webfetch-prompt);
   padding: 0.5rem;
   border-radius: 3px;
   font-style: italic;
   font-size: 0.8125rem;
   margin-bottom: 0.5rem;
-}
-
-@media (prefers-color-scheme: dark) {
-  .webfetch-tool .tool-prompt {
-    background-color: var(--bg-prompt-dark, #1a1a1a);
-  }
 }

--- a/app/assets/stylesheets/websearch-tool.css
+++ b/app/assets/stylesheets/websearch-tool.css
@@ -1,55 +1,40 @@
 .websearch-tool {
-  background-color: var(--bg-search, #f3e5f5);
-  color: var(--text-search, #1a1a1a);
+  background-color: var(--bg-websearch-tool);
+  color: var(--text);
   padding: 0.75rem 1rem;
   border-radius: 4px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 0.875rem;
   line-height: 1.6;
   margin: 0.5rem 0;
-  border-left: 3px solid var(--border-search, #9c27b0);
+  border-left: 3px solid var(--border-websearch);
 }
 
-@media (prefers-color-scheme: dark) {
-  .websearch-tool {
-    background-color: var(--bg-search-dark, #2e1a33);
-    color: var(--text-search-dark, #e6e6e6);
-    border-left: 3px solid var(--border-search-dark, #7b1fa2);
-  }
-}
-
-.websearch-tool .tool-header {
+.websearch-tool > .tool-header {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--label-search, #6a1b9a);
+  background-color: var(--bg-websearch-header);
+  margin: -0.75rem -1rem 0.75rem -1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 4px 4px 0 0;
 }
 
-@media (prefers-color-scheme: dark) {
-  .websearch-tool .tool-header {
-    color: var(--label-search-dark, #ba68c8);
-  }
-}
-
-.websearch-tool .tool-icon {
+.websearch-tool > .tool-header > .tool-icon {
   font-size: 1.1rem;
+  color: var(--color-websearch-icon);
 }
 
-.websearch-tool .tool-query {
-  background-color: var(--bg-content, #fff);
-  padding: 0.5rem;
-  border-radius: 3px;
-  overflow-x: auto;
+.websearch-tool > .tool-header > .tool-label {
+  font-weight: 600;
+  color: var(--color-websearch-icon);
+}
+
+.websearch-tool > .tool-header > .query {
+  margin-left: auto;
   font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
   font-size: 0.8125rem;
-  margin-bottom: 0.5rem;
+  color: var(--text-secondary);
   font-weight: 500;
-}
-
-@media (prefers-color-scheme: dark) {
-  .websearch-tool .tool-query {
-    background-color: var(--bg-content-dark, #1a0f1d);
-  }
 }

--- a/app/assets/stylesheets/websearch-tool.css
+++ b/app/assets/stylesheets/websearch-tool.css
@@ -1,0 +1,55 @@
+.websearch-tool {
+  background-color: var(--bg-search, #f3e5f5);
+  color: var(--text-search, #1a1a1a);
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin: 0.5rem 0;
+  border-left: 3px solid var(--border-search, #9c27b0);
+}
+
+@media (prefers-color-scheme: dark) {
+  .websearch-tool {
+    background-color: var(--bg-search-dark, #2e1a33);
+    color: var(--text-search-dark, #e6e6e6);
+    border-left: 3px solid var(--border-search-dark, #7b1fa2);
+  }
+}
+
+.websearch-tool .tool-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--label-search, #6a1b9a);
+}
+
+@media (prefers-color-scheme: dark) {
+  .websearch-tool .tool-header {
+    color: var(--label-search-dark, #ba68c8);
+  }
+}
+
+.websearch-tool .tool-icon {
+  font-size: 1.1rem;
+}
+
+.websearch-tool .tool-query {
+  background-color: var(--bg-content, #fff);
+  padding: 0.5rem;
+  border-radius: 3px;
+  overflow-x: auto;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+  font-size: 0.8125rem;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme: dark) {
+  .websearch-tool .tool-query {
+    background-color: var(--bg-content-dark, #1a0f1d);
+  }
+}

--- a/app/models/log_processor/concerns/claude_json_processing.rb
+++ b/app/models/log_processor/concerns/claude_json_processing.rb
@@ -35,6 +35,12 @@ module LogProcessor::Concerns::ClaudeJsonProcessing
           { raw_response: item_json, type: "Step::GlobTool", content: extract_content(item), tool_use_id: tool_use_id }
         elsif tool_use && tool_use["name"] == "Grep"
           { raw_response: item_json, type: "Step::GrepTool", content: extract_content(item), tool_use_id: tool_use_id }
+        elsif tool_use && tool_use["name"] == "LS"
+          { raw_response: item_json, type: "Step::LsTool", content: extract_content(item), tool_use_id: tool_use_id }
+        elsif tool_use && tool_use["name"] == "WebFetch"
+          { raw_response: item_json, type: "Step::WebFetchTool", content: extract_content(item), tool_use_id: tool_use_id }
+        elsif tool_use && tool_use["name"] == "WebSearch"
+          { raw_response: item_json, type: "Step::WebSearchTool", content: extract_content(item), tool_use_id: tool_use_id }
         else
           { raw_response: item_json, type: "Step::ToolCall", content: extract_content(item), tool_use_id: tool_use_id }
         end
@@ -105,6 +111,12 @@ module LogProcessor::Concerns::ClaudeJsonProcessing
               tool_use["input"]["pattern"] || tool_use["input"].to_json
             elsif tool_use["name"] == "Grep"
               tool_use["input"]["pattern"] || tool_use["input"].to_json
+            elsif tool_use["name"] == "LS"
+              tool_use["input"]["path"] || tool_use["input"].to_json
+            elsif tool_use["name"] == "WebFetch"
+              tool_use["input"]["url"] || tool_use["input"].to_json
+            elsif tool_use["name"] == "WebSearch"
+              tool_use["input"]["query"] || tool_use["input"].to_json
             else
               "name: #{tool_use['name']}\ninputs: #{tool_use['input'].to_json}"
             end

--- a/app/models/step/ls_tool.rb
+++ b/app/models/step/ls_tool.rb
@@ -1,0 +1,5 @@
+class Step::LsTool < Step::ToolCall
+  def path
+    tool_inputs&.dig("path") || content
+  end
+end

--- a/app/models/step/web_fetch_tool.rb
+++ b/app/models/step/web_fetch_tool.rb
@@ -1,0 +1,9 @@
+class Step::WebFetchTool < Step::ToolCall
+  def url
+    tool_inputs&.dig("url")
+  end
+
+  def prompt
+    tool_inputs&.dig("prompt")
+  end
+end

--- a/app/models/step/web_search_tool.rb
+++ b/app/models/step/web_search_tool.rb
@@ -1,0 +1,5 @@
+class Step::WebSearchTool < Step::ToolCall
+  def query
+    tool_inputs&.dig("query")
+  end
+end

--- a/app/views/step/ls_tools/_ls_tool.html.erb
+++ b/app/views/step/ls_tools/_ls_tool.html.erb
@@ -1,0 +1,11 @@
+<div class="ls-tool">
+  <div class="tool-header">
+    <span class="tool-icon">📋</span>
+    <span class="tool-name">List Directory</span>
+  </div>
+  <div class="tool-path">
+    <%= ls_tool.path %>
+  </div>
+  
+  <%= render "step/tool_calls/tool_result_section", tool_call: ls_tool %>
+</div>

--- a/app/views/step/ls_tools/_ls_tool.html.erb
+++ b/app/views/step/ls_tools/_ls_tool.html.erb
@@ -1,10 +1,8 @@
-<div class="ls-tool">
+<div class="ls-tool" data-tool-id="<%= ls_tool.tool_id %>">
   <div class="tool-header">
     <span class="tool-icon">📋</span>
-    <span class="tool-name">List Directory</span>
-  </div>
-  <div class="tool-path">
-    <%= ls_tool.path %>
+    <span class="tool-label">List Directory</span>
+    <span class="file-path"><%= ls_tool.path %></span>
   </div>
   
   <%= render "step/tool_calls/tool_result_section", tool_call: ls_tool %>

--- a/app/views/step/web_fetch_tools/_web_fetch_tool.html.erb
+++ b/app/views/step/web_fetch_tools/_web_fetch_tool.html.erb
@@ -1,0 +1,16 @@
+<div class="webfetch-tool">
+  <div class="tool-header">
+    <span class="tool-icon">🌐</span>
+    <span class="tool-name">Web Fetch</span>
+  </div>
+  <div class="tool-url">
+    <%= web_fetch_tool.url %>
+  </div>
+  <% if web_fetch_tool.prompt.present? %>
+    <div class="tool-prompt">
+      <%= web_fetch_tool.prompt %>
+    </div>
+  <% end %>
+  
+  <%= render "step/tool_calls/tool_result_section", tool_call: web_fetch_tool %>
+</div>

--- a/app/views/step/web_fetch_tools/_web_fetch_tool.html.erb
+++ b/app/views/step/web_fetch_tools/_web_fetch_tool.html.erb
@@ -1,13 +1,11 @@
-<div class="webfetch-tool">
+<div class="webfetch-tool" data-tool-id="<%= web_fetch_tool.tool_id %>">
   <div class="tool-header">
     <span class="tool-icon">🌐</span>
-    <span class="tool-name">Web Fetch</span>
-  </div>
-  <div class="tool-url">
-    <%= web_fetch_tool.url %>
+    <span class="tool-label">Web Fetch</span>
+    <span class="url"><%= web_fetch_tool.url %></span>
   </div>
   <% if web_fetch_tool.prompt.present? %>
-    <div class="tool-prompt">
+    <div class="prompt">
       <%= web_fetch_tool.prompt %>
     </div>
   <% end %>

--- a/app/views/step/web_search_tools/_web_search_tool.html.erb
+++ b/app/views/step/web_search_tools/_web_search_tool.html.erb
@@ -1,10 +1,8 @@
-<div class="websearch-tool">
+<div class="websearch-tool" data-tool-id="<%= web_search_tool.tool_id %>">
   <div class="tool-header">
     <span class="tool-icon">🔍</span>
-    <span class="tool-name">Web Search</span>
-  </div>
-  <div class="tool-query">
-    <%= web_search_tool.query %>
+    <span class="tool-label">Web Search</span>
+    <span class="query"><%= web_search_tool.query %></span>
   </div>
   
   <%= render "step/tool_calls/tool_result_section", tool_call: web_search_tool %>

--- a/app/views/step/web_search_tools/_web_search_tool.html.erb
+++ b/app/views/step/web_search_tools/_web_search_tool.html.erb
@@ -1,0 +1,11 @@
+<div class="websearch-tool">
+  <div class="tool-header">
+    <span class="tool-icon">🔍</span>
+    <span class="tool-name">Web Search</span>
+  </div>
+  <div class="tool-query">
+    <%= web_search_tool.query %>
+  </div>
+  
+  <%= render "step/tool_calls/tool_result_section", tool_call: web_search_tool %>
+</div>

--- a/test/models/log_processor/claude_json_test.rb
+++ b/test/models/log_processor/claude_json_test.rb
@@ -73,10 +73,10 @@ class LogProcessor::ClaudeJsonTest < ActiveSupport::TestCase
         "content": [
           {
             "type": "tool_use",
-            "name": "WebFetch",
+            "name": "UnknownTool",
             "input": {
-              "url": "https://example.com",
-              "prompt": "What is the title?"
+              "param1": "value1",
+              "param2": "value2"
             }
           }
         ]
@@ -86,8 +86,8 @@ class LogProcessor::ClaudeJsonTest < ActiveSupport::TestCase
     result = processor.process(logs)
 
     assert_equal 1, result.size
-    assert_equal "Step::WebFetchTool", result[0][:type]
-    expected_content = "https://example.com"
+    assert_equal "Step::ToolCall", result[0][:type]
+    expected_content = "name: UnknownTool\ninputs: {\"param1\":\"value1\",\"param2\":\"value2\"}"
     assert_equal expected_content, result[0][:content]
   end
 
@@ -114,5 +114,78 @@ class LogProcessor::ClaudeJsonTest < ActiveSupport::TestCase
     assert_equal 1, result.size
     assert_equal "Step::BashTool", result[0][:type]
     assert_equal "ls -la", result[0][:content]
+  end
+
+  test "process creates Step::LsTool for LS tool calls" do
+    processor = LogProcessor::ClaudeJson.new
+    logs = '{
+      "type": "assistant",
+      "message": {
+        "content": [
+          {
+            "type": "tool_use",
+            "name": "LS",
+            "input": {
+              "path": "/workspace"
+            }
+          }
+        ]
+      }
+    }'
+
+    result = processor.process(logs)
+
+    assert_equal 1, result.size
+    assert_equal "Step::LsTool", result[0][:type]
+    assert_equal "/workspace", result[0][:content]
+  end
+
+  test "process creates Step::WebFetchTool for WebFetch tool calls" do
+    processor = LogProcessor::ClaudeJson.new
+    logs = '{
+      "type": "assistant",
+      "message": {
+        "content": [
+          {
+            "type": "tool_use",
+            "name": "WebFetch",
+            "input": {
+              "url": "https://example.com",
+              "prompt": "What is the title?"
+            }
+          }
+        ]
+      }
+    }'
+
+    result = processor.process(logs)
+
+    assert_equal 1, result.size
+    assert_equal "Step::WebFetchTool", result[0][:type]
+    assert_equal "https://example.com", result[0][:content]
+  end
+
+  test "process creates Step::WebSearchTool for WebSearch tool calls" do
+    processor = LogProcessor::ClaudeJson.new
+    logs = '{
+      "type": "assistant",
+      "message": {
+        "content": [
+          {
+            "type": "tool_use",
+            "name": "WebSearch",
+            "input": {
+              "query": "cats"
+            }
+          }
+        ]
+      }
+    }'
+
+    result = processor.process(logs)
+
+    assert_equal 1, result.size
+    assert_equal "Step::WebSearchTool", result[0][:type]
+    assert_equal "cats", result[0][:content]
   end
 end

--- a/test/models/log_processor/claude_json_test.rb
+++ b/test/models/log_processor/claude_json_test.rb
@@ -86,8 +86,8 @@ class LogProcessor::ClaudeJsonTest < ActiveSupport::TestCase
     result = processor.process(logs)
 
     assert_equal 1, result.size
-    assert_equal "Step::ToolCall", result[0][:type]
-    expected_content = "name: WebFetch\ninputs: {\"url\":\"https://example.com\",\"prompt\":\"What is the title?\"}"
+    assert_equal "Step::WebFetchTool", result[0][:type]
+    expected_content = "https://example.com"
     assert_equal expected_content, result[0][:content]
   end
 


### PR DESCRIPTION
## Summary
- Added dedicated styling for three additional tools: LS, WebFetch, and WebSearch
- Created separate model classes and view partials following the existing polymorphic pattern
- Implemented tool-specific icons and color schemes with full dark mode support

## Changes
- **LS Tool**: List directory tool with 📋 icon and folder-themed colors (browns/tans)
- **WebFetch Tool**: Web fetching tool with 🌐 icon and internet-themed colors (blues)
- **WebSearch Tool**: Web search tool with 🔍 icon and search-themed colors (purples)

Each tool now has:
- Its own model class inheriting from `Step::ToolCall`
- A dedicated view partial with custom layout and icon
- Tool-specific CSS with light/dark mode support
- Consistent styling that matches existing tools

## Test plan
- [x] Run tests with `bin/rails t` - all pass
- [x] Run linter with `bundle exec rubocop -A` - clean
- [x] Run security analysis with `bin/brakeman --no-pager` - no issues
- [ ] Visual inspection of tools in the UI

🤖 Generated with [Claude Code](https://claude.ai/code)