### PR TITLE
Add secrets support for agents

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -48,6 +48,8 @@ class AgentsController < ApplicationController
         create_volumes_from_config(@agent, volumes_config)
       end
 
+      update_agent_secrets if params[:agent][:secrets].present?
+
       redirect_to @agent, notice: "Agent was successfully updated."
     else
       render :edit, status: :unprocessable_entity
@@ -88,5 +90,17 @@ class AgentsController < ApplicationController
       end
     rescue JSON::ParserError
       Rails.logger.error "Invalid JSON in volumes_config"
+    end
+
+    def update_agent_secrets
+      secrets_json = params[:agent][:secrets]
+      return if secrets_json.blank?
+
+      begin
+        secrets_hash = JSON.parse(secrets_json)
+        @agent.update_secrets(secrets_hash)
+      rescue JSON::ParserError
+        flash[:alert] = "Invalid JSON format for secrets"
+      end
     end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -60,6 +60,26 @@ class Agent < ApplicationRecord
     vars
   end
 
+  def update_secrets(secrets_hash)
+    return unless secrets_hash.is_a?(Hash)
+
+    secrets_hash.each do |key, value|
+      next if key.blank? || value.blank?
+
+      secret = secrets.find_or_initialize_by(key: key)
+      secret.value = value
+      secret.save!
+    end
+  end
+
+  def secrets_hash
+    secrets.pluck(:key, :value).to_h
+  end
+
+  def secret_values
+    secrets.pluck(:value)
+  end
+
   def start_arguments=(value)
     parsed = value.is_a?(String) && value.present? ? JSON.parse(value) : value
     super(parsed)

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -52,6 +52,12 @@
   </div>
 
   <div>
+    <%= form.label :secrets, "Secrets (JSON)" %><br>
+    <%= text_area_tag "agent[secrets]", "", placeholder: '{"API_KEY": "secret", "DATABASE_PASSWORD": "password"}', rows: 3 %>
+    <small class="form-help">JSON format. Leave empty to keep existing secrets. Values are encrypted and hidden after saving.</small>
+  </div>
+
+  <div>
     <%= form.label :log_processor %><br>
     <%= form.select :log_processor, 
         options_for_select(

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -49,6 +49,12 @@
   </ul>
 <% end %>
 
+<% if @agent.secrets.any? %>
+<h2>Agent Secrets</h2>
+<p>Configured secret keys: <strong><%= @agent.secrets.pluck(:key).join(', ') %></strong></p>
+<p><small>Values are encrypted and hidden for security.</small></p>
+<% end %>
+
 <h2>User Instructions</h2>
 <% if Current.user.instructions.present? && @agent.instructions_mount_path.present? %>
   <p>


### PR DESCRIPTION
## Summary
- Add secrets JSON input field to agent edit form
- Add secrets display to agent show page with encrypted value protection
- Add update_secrets method to Agent model following project secrets pattern
- Add secrets update logic to agents controller with JSON parsing and error handling
- Secrets are automatically included in container environment variables

🤖 Generated with [Claude Code](https://claude.ai/code)