### PR TITLE
Add email/password change functionality to settings

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -1,0 +1,28 @@
+class AccountSettingsController < ApplicationController
+  def edit
+    @user = Current.user
+  end
+
+  def update
+    @user = Current.user
+
+    # Filter out password fields if they're blank
+    filtered_params = account_params
+    if filtered_params[:password].blank?
+      filtered_params.delete(:password)
+      filtered_params.delete(:password_confirmation)
+    end
+
+    if @user.update(filtered_params)
+      redirect_to user_settings_path, notice: "Account settings updated successfully"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def account_params
+    params.require(:user).permit(:email_address, :password, :password_confirmation)
+  end
+end

--- a/app/views/account_settings/edit.html.erb
+++ b/app/views/account_settings/edit.html.erb
@@ -1,0 +1,27 @@
+<h1>Change Email/Password</h1>
+
+<%= form_with(model: @user, url: account_settings_path, method: :patch) do |form| %>
+  <%= form_errors(@user) %>
+
+  <div>
+    <%= form.label :email_address, "Email Address" %><br>
+    <%= form.email_field :email_address %>
+  </div>
+
+  <div>
+    <%= form.label :password, "New Password" %><br>
+    <%= form.password_field :password, placeholder: "Leave blank to keep current password" %>
+    <small>Minimum 12 characters</small>
+  </div>
+
+  <div>
+    <%= form.label :password_confirmation, "Confirm New Password" %><br>
+    <%= form.password_field :password_confirmation %>
+  </div>
+
+  <div>
+    <%= form.submit "Update Account", class: "button" %>
+  </div>
+<% end %>
+
+<%= link_to 'Cancel', user_settings_path %>

--- a/app/views/user_settings/show.html.erb
+++ b/app/views/user_settings/show.html.erb
@@ -48,6 +48,7 @@
 
 <p>
   <%= link_to 'Edit Settings', edit_user_settings_path, class: 'button' %>
+  <%= link_to 'Change Email/Password', edit_account_settings_path, class: 'button' %>
 </p>
 
 <%= link_to 'Back', root_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
   resource :user_settings, only: %i[show edit update]
+  resource :account_settings, only: %i[edit update]
   resources :agents do
     member do
       get "oauth/login_start", to: "claude_oauth#login_start", as: :oauth_login_start


### PR DESCRIPTION
## Summary
- Added a dedicated form for users to change their email address and password
- Created new AccountSettingsController to handle these updates separately from other user settings
- Added "Change Email/Password" button to the main settings page for easy access

## Test plan
- [x] Navigate to user settings page
- [x] Click "Change Email/Password" button
- [x] Update email address and verify it saves correctly
- [x] Update password and verify it saves correctly
- [x] Leave password fields blank and verify existing password is preserved
- [x] Verify form displays validation errors appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)