### PR TITLE
Show warning message when SMTP not configured on password reset page

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -3,6 +3,7 @@ class PasswordsController < ApplicationController
   before_action :set_user_by_token, only: %i[ edit update ]
 
   def new
+    @smtp_configured = Rails.application.config.action_mailer.smtp_settings.present?
   end
 
   def create

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -2,7 +2,11 @@
 
 <%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
 
-<%= form_with url: passwords_path do |form| %>
-  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
-  <%= form.submit "Email reset instructions" %>
+<% if @smtp_configured %>
+  <%= form_with url: passwords_path do |form| %>
+    <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
+    <%= form.submit "Email reset instructions" %>
+  <% end %>
+<% else %>
+  <p>You should really be careful with theses...</p>
 <% end %>


### PR DESCRIPTION
## Summary
- Display warning message "You should really be careful with theses..." instead of password reset form when SMTP is not configured
- Check SMTP configuration in PasswordsController#new action
- Conditionally render form or warning in the view

## Test plan
- [x] Run tests: `bin/rails t` ✅
- [x] Run linter: `bundle exec rubocop -A` ✅
- [x] Run security analysis: `bin/brakeman --no-pager` ✅
- [ ] Visit /passwords/new with SMTP configured - should show form
- [ ] Visit /passwords/new without SMTP configured - should show warning message

🤖 Generated with [Claude Code](https://claude.ai/code)