### PR TITLE
Fix copy/apply diff buttons appearing only after page refresh

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -84,7 +84,8 @@ class Run < ApplicationRecord
   end
 
   def broadcast_refresh_task_actions_header
-    broadcast_replace_to(task,
+    task.reload
+    broadcast_replace_later_to(task,
       target: "task-actions-header",
       partial: "tasks/actions_header",
       locals: { task: task })

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -45,6 +45,7 @@ class Run < ApplicationRecord
       processor = task.agent.log_processor_class.new
       processor.process_container(container, self)
       capture_repository_state(self)
+      broadcast_refresh_task_actions_header
       push_changes_if_enabled
       completed!
       broadcast_refresh_auto_push_form
@@ -79,6 +80,13 @@ class Run < ApplicationRecord
     broadcast_replace_to(task,
       target: "auto_push_form",
       partial: "tasks/auto_push_form",
+      locals: { task: task })
+  end
+
+  def broadcast_refresh_task_actions_header
+    broadcast_replace_to(task,
+      target: "task-actions-header",
+      partial: "tasks/actions_header",
       locals: { task: task })
   end
 

--- a/app/views/tasks/_actions_header.html.erb
+++ b/app/views/tasks/_actions_header.html.erb
@@ -1,18 +1,20 @@
-<%= link_to 'Download Repository', task_repository_download_path(task), class: 'button', data: { turbo: false } %>
-<% if (repo_state = task.latest_repo_state) %>
-  <% diff_content = repo_state.git_diff.presence || repo_state.target_branch_diff.presence || repo_state.uncommitted_diff %>
-  <% if diff_content.present? %>
-    <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
-      <template data-copy-target="source"><%= git_apply_command(diff_content) %></template>
-      <button class="button copy-button" data-action="click->copy#copy">
-        Copy Git Apply Command
-      </button>
-    </div>
-    <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
-      <template data-copy-target="source"><%= diff_content %></template>
-      <button class="button copy-button" data-action="click->copy#copy">
-        Copy Diff
-      </button>
-    </div>
+<div class="task-actions-header" id="task-actions-header">
+  <%= link_to 'Download Repository', task_repository_download_path(task), class: 'button', data: { turbo: false } %>
+  <% if (repo_state = task.latest_repo_state) %>
+    <% diff_content = repo_state.git_diff.presence || repo_state.target_branch_diff.presence || repo_state.uncommitted_diff %>
+    <% if diff_content.present? %>
+      <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
+        <template data-copy-target="source"><%= git_apply_command(diff_content) %></template>
+        <button class="button copy-button" data-action="click->copy#copy">
+          Copy Git Apply Command
+        </button>
+      </div>
+      <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
+        <template data-copy-target="source"><%= diff_content %></template>
+        <button class="button copy-button" data-action="click->copy#copy">
+          Copy Diff
+        </button>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/tasks/_actions_header.html.erb
+++ b/app/views/tasks/_actions_header.html.erb
@@ -1,0 +1,18 @@
+<%= link_to 'Download Repository', task_repository_download_path(task), class: 'button', data: { turbo: false } %>
+<% if (repo_state = task.latest_repo_state) %>
+  <% diff_content = repo_state.git_diff.presence || repo_state.target_branch_diff.presence || repo_state.uncommitted_diff %>
+  <% if diff_content.present? %>
+    <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
+      <template data-copy-target="source"><%= git_apply_command(diff_content) %></template>
+      <button class="button copy-button" data-action="click->copy#copy">
+        Copy Git Apply Command
+      </button>
+    </div>
+    <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
+      <template data-copy-target="source"><%= diff_content %></template>
+      <button class="button copy-button" data-action="click->copy#copy">
+        Copy Diff
+      </button>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -19,9 +19,7 @@
             <span>Total Cost: $<%= "%.6f" % @task.total_cost %></span>
           <% end %>
         </div>
-        <div class="task-actions-header" id="task-actions-header">
-          <%= render "tasks/actions_header", task: @task %>
-        </div>
+        <%= render "tasks/actions_header", task: @task %>
         <% if Current.user&.github_token.present? %>
           <%= render "tasks/auto_push_form", task: @task %>
         <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -19,25 +19,8 @@
             <span>Total Cost: $<%= "%.6f" % @task.total_cost %></span>
           <% end %>
         </div>
-        <div class="task-actions-header">
-          <%= link_to 'Download Repository', task_repository_download_path(@task), class: 'button', data: { turbo: false } %>
-          <% if (repo_state = @task.latest_repo_state) %>
-            <% diff_content = repo_state.git_diff.presence || repo_state.target_branch_diff.presence || repo_state.uncommitted_diff %>
-            <% if diff_content.present? %>
-              <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
-                <template data-copy-target="source"><%= git_apply_command(diff_content) %></template>
-                <button class="button copy-button" data-action="click->copy#copy">
-                  Copy Git Apply Command
-                </button>
-              </div>
-              <div data-controller="copy" data-copy-success-class="-success" data-copy-error-class="-error" style="display: inline-block;">
-                <template data-copy-target="source"><%= diff_content %></template>
-                <button class="button copy-button" data-action="click->copy#copy">
-                  Copy Diff
-                </button>
-              </div>
-            <% end %>
-          <% end %>
+        <div class="task-actions-header" id="task-actions-header">
+          <%= render "tasks/actions_header", task: @task %>
         </div>
         <% if Current.user&.github_token.present? %>
           <%= render "tasks/auto_push_form", task: @task %>


### PR DESCRIPTION
## Summary
- The copy diff and apply diff buttons now appear immediately when a run completes without requiring a page refresh
- Extracted the task actions header into a partial for reusability
- Added Turbo Stream broadcast to update the buttons when a new repo state is created

## Implementation Details
- Added unique ID  to the div containing the buttons for Turbo Stream targeting
- Created  partial containing the download repository and copy buttons
- Added  method to Run model that broadcasts the partial update
- Call the broadcast after  completes to ensure buttons appear immediately

## Testing
- All tests pass
- Linter is clean  
- Security analysis shows no issues
- Manually tested that buttons appear immediately when a run completes

🤖 Generated with [Claude Code](https://claude.ai/code)