### PR TITLE
Implement nested forms for volumes in agents

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -10,6 +10,7 @@ class Agent < ApplicationRecord
   accepts_nested_attributes_for :agent_specific_settings, allow_destroy: true, reject_if: :reject_new_destroyed_settings
   accepts_nested_attributes_for :secrets, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :env_variables, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :volumes, allow_destroy: true, reject_if: :all_blank
 
   validates :name, presence: true
   validates :docker_image, presence: true
@@ -18,24 +19,7 @@ class Agent < ApplicationRecord
 
   before_save :update_agent_specific_setting
 
-  attr_accessor :volumes_config, :env_variables_json, :agent_specific_setting_type
-
-  def volumes_config
-    return @volumes_config if @volumes_config.present?
-    return "" if volumes.empty?
-
-    volumes.map do |volume|
-      if volume.external?
-        [ volume.name, {
-          "path" => volume.path,
-          "external" => true,
-          "external_name" => volume.external_name
-        } ]
-      else
-        [ volume.name, volume.path ]
-      end
-    end.to_h.to_json
-  end
+  attr_accessor :env_variables_json, :agent_specific_setting_type
 
   def env_variables_json
     return @env_variables_json if @env_variables_json.present?

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -32,18 +32,12 @@
     <%= form.text_field :workplace_path %>
   </div>
 
-  <div>
-    <%= form.label :volumes_config, "Volumes (JSON format)" %><br>
-    <%= form.text_area :volumes_config, readonly: !agent.new_record? %>
-    <% unless agent.new_record? %>
-      <small class="form-help">Volumes cannot be edited after creation</small>
-    <% else %>
-      <small class="form-help">
-        Format: <code>{"volume_name": "/path"}</code> for managed volumes<br>
-        or <code>{"volume_name": {"path": "/path", "external": true, "external_name": "docker_volume_name"}}</code> for external Docker volumes
-      </small>
-    <% end %>
-  </div>
+  <%= render "shared/volumes_fields", 
+             form: form, 
+             parent: agent, 
+             title: "Volumes",
+             singular_name: "Volume",
+             help_text: "Define volumes to mount in the container. External volumes use existing Docker volumes." %>
 
   <%= render "shared/env_variables_fields", 
              form: form, 

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -35,7 +35,12 @@
   <h2>Volumes</h2>
   <ul>
     <% @agent.volumes.each do |volume| %>
-      <li><strong><%= volume.name %>:</strong> <%= volume.path %></li>
+      <li>
+        <strong><%= volume.name %>:</strong> <%= volume.path %>
+        <% if volume.external? %>
+          <span class="status-indicator -info">External: <%= volume.external_name %></span>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/shared/_volumes_fields.html.erb
+++ b/app/views/shared/_volumes_fields.html.erb
@@ -1,0 +1,68 @@
+<div data-controller="nested-fields">
+  <h3><%= title %></h3>
+  <% if local_assigns[:help_text] %>
+    <small class="form-help" style="display: block; margin-bottom: 10px;"><%= help_text %></small>
+  <% end %>
+  <div data-nested-fields-target="fields">
+    <% parent.volumes.each do |volume| %>
+      <div class="nested-field" style="border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; border-radius: 5px;">
+        <%= form.fields_for :volumes, volume do |volume_field| %>
+          <%= volume_field.hidden_field :id %>
+          <%= volume_field.hidden_field :_destroy %>
+          
+          <div style="display: flex; gap: 10px; margin-bottom: 10px;">
+            <%= volume_field.text_field :name, placeholder: "Volume name", style: "flex: 1;" %>
+            <%= volume_field.text_field :path, placeholder: "Container path", style: "flex: 1;" %>
+          </div>
+          
+          <div style="display: flex; gap: 10px; align-items: center;">
+            <label style="display: flex; align-items: center; gap: 5px;">
+              <%= volume_field.check_box :external %>
+              External Docker volume
+            </label>
+            <div data-volume-external-field style="display: <%= volume.external? ? 'block' : 'none' %>; flex: 1;">
+              <%= volume_field.text_field :external_name, placeholder: "External volume name", style: "width: 100%;" %>
+            </div>
+            <button type="button" data-action="click->nested-fields#remove" style="padding: 5px 10px; margin-left: auto;">Remove</button>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  
+  <button type="button" data-action="click->nested-fields#add" style="margin-top: 10px;">Add <%= singular_name %></button>
+  
+  <template data-nested-fields-target="template">
+    <div class="nested-field" style="border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; border-radius: 5px;">
+      <%= form.fields_for :volumes, parent.volumes.build, child_index: "__INDEX__" do |volume_field| %>
+        <div style="display: flex; gap: 10px; margin-bottom: 10px;">
+          <%= volume_field.text_field :name, placeholder: "Volume name", style: "flex: 1;" %>
+          <%= volume_field.text_field :path, placeholder: "Container path", style: "flex: 1;" %>
+        </div>
+        
+        <div style="display: flex; gap: 10px; align-items: center;">
+          <label style="display: flex; align-items: center; gap: 5px;">
+            <%= volume_field.check_box :external %>
+            External Docker volume
+          </label>
+          <div data-volume-external-field style="display: none; flex: 1;">
+            <%= volume_field.text_field :external_name, placeholder: "External volume name", style: "width: 100%;" %>
+          </div>
+          <button type="button" data-action="click->nested-fields#remove" style="padding: 5px 10px; margin-left: auto;">Remove</button>
+        </div>
+      <% end %>
+    </div>
+  </template>
+</div>
+
+<script>
+  document.addEventListener('change', function(event) {
+    if (event.target.type === 'checkbox' && event.target.name.includes('[external]')) {
+      const field = event.target.closest('.nested-field');
+      const externalField = field.querySelector('[data-volume-external-field]');
+      if (externalField) {
+        externalField.style.display = event.target.checked ? 'block' : 'none';
+      }
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary
- Replace JSON textarea for volumes with dynamic nested forms (similar to environment variables)
- Add support for external Docker volumes with checkbox toggle
- Improve user experience for managing agent volumes

## Changes
- Added `accepts_nested_attributes_for :volumes` to Agent model
- Updated AgentsController to handle `volumes_attributes` instead of custom JSON parsing
- Created `_volumes_fields.html.erb` partial for dynamic volume management
- Added checkbox for external volumes that shows/hides external volume name field
- Removed `volumes_config` attribute accessor and JSON handling
- Enhanced show view to display external volume information

## Implementation Details
The implementation follows the same pattern as environment variables:
- Uses Rails nested attributes
- Stimulus controller for dynamic add/remove functionality
- Proper handling of `_destroy` markers for removal
- Support for both managed and external Docker volumes

Claude label