### PR TITLE
Move action buttons to top of settings page

### DIFF
--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -57,5 +57,4 @@
   </div>
 <% end %>
 
-<%= link_to 'Show', user_settings_path %> |
-<%= link_to 'Back', root_path %>
+<%= link_to 'Show', user_settings_path %>

--- a/app/views/user_settings/show.html.erb
+++ b/app/views/user_settings/show.html.erb
@@ -1,5 +1,10 @@
 <h1>User Settings</h1>
 
+<p>
+  <%= link_to 'Edit Settings', edit_user_settings_path, class: 'button' %>
+  <%= link_to 'Change Email/Password', edit_account_settings_path, class: 'button' %>
+</p>
+
 <div>
   <strong>Email:</strong> <%= @user.email_address %>
 </div>
@@ -45,10 +50,3 @@
 <div>
   <strong>Shrimp Mode 🍤:</strong> <%= @user.shrimp_mode? ? "Enabled" : "Disabled" %>
 </div>
-
-<p>
-  <%= link_to 'Edit Settings', edit_user_settings_path, class: 'button' %>
-  <%= link_to 'Change Email/Password', edit_account_settings_path, class: 'button' %>
-</p>
-
-<%= link_to 'Back', root_path %>


### PR DESCRIPTION
## Summary
- Moved 'Edit Settings' and 'Change Email/Password' buttons to the top of the user settings page for better UX
- Removed the 'Back' button from settings pages as requested
- The Cancel link in the account settings edit page was kept as it serves a different purpose

🤖 Generated with [Claude Code](https://claude.ai/code)