### PR TITLE
Fix race condition in run creation

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -12,7 +12,7 @@ class Run < ApplicationRecord
   attr_accessor :skip_agent
 
   before_create :cancel_running_runs
-  after_create :enqueue_job, unless: :skip_agent
+  after_create_commit :enqueue_job, unless: :skip_agent
   after_update_commit :broadcast_update
   after_create_commit :broadcast_chat_append
   after_update_commit :broadcast_chat_replace


### PR DESCRIPTION
## Summary
- Changed `after_create` to `after_create_commit` for the `enqueue_job` callback in the Run model
- This ensures the run record is fully committed to the database before the RunJob tries to find it
- Fixes the "run id=X doesn't exist" errors occurring in production

The race condition was happening because:
1. When a Run is created, it uses `after_create` callback to enqueue the job
2. `after_create` runs **before** the database transaction is committed
3. The job is enqueued immediately but might execute before the transaction commits
4. When `RunJob` tries to find the run by ID, it might not exist yet in the database

Using `after_create_commit` guarantees that the run record exists in the database before the job tries to find it.

🏷️ claude