### PR TITLE
Add environment variables to projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -43,7 +43,6 @@ class ProjectsController < ApplicationController
 
   def project_params
     params.require(:project).permit(:name, :description, :repository_url, :setup_script, :repo_path, :dev_dockerfile_path, :dev_container_port,
-                                     :env_variables_json,
                                      secrets_attributes: [ :id, :key, :value, :_destroy ],
                                      env_variables_attributes: [ :id, :key, :value, :_destroy ])
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -43,6 +43,8 @@ class ProjectsController < ApplicationController
 
   def project_params
     params.require(:project).permit(:name, :description, :repository_url, :setup_script, :repo_path, :dev_dockerfile_path, :dev_container_port,
-                                     secrets_attributes: [ :id, :key, :value, :_destroy ])
+                                     :env_variables_json,
+                                     secrets_attributes: [ :id, :key, :value, :_destroy ],
+                                     env_variables_attributes: [ :id, :key, :value, :_destroy ])
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,30 +11,6 @@ class Project < ApplicationRecord
   validates :name, presence: true
   validate :valid_repository_url
 
-  attr_accessor :env_variables_json
-
-  def env_variables_json
-    return @env_variables_json if @env_variables_json.present?
-    return "" if env_variables.empty?
-
-    env_variables.pluck(:key, :value).to_h.to_json
-  end
-
-  def env_variables_json=(value)
-    @env_variables_json = value
-    return if value.blank?
-
-    begin
-      parsed = JSON.parse(value)
-      env_variables.destroy_all
-      parsed.each do |key, val|
-        env_variables.build(key: key, value: val)
-      end
-    rescue JSON::ParserError
-      errors.add(:env_variables_json, "must be valid JSON")
-    end
-  end
-
   def secrets_hash
     secrets.pluck(:key, :value).to_h
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,12 +3,37 @@ class Project < ApplicationRecord
 
   has_many :tasks, dependent: :destroy
   has_many :secrets, as: :secretable, dependent: :destroy
+  has_many :env_variables, as: :envable, dependent: :destroy, class_name: "EnvVariable"
 
   accepts_nested_attributes_for :secrets, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :env_variables, allow_destroy: true, reject_if: :all_blank
 
   validates :name, presence: true
   validate :valid_repository_url
 
+  attr_accessor :env_variables_json
+
+  def env_variables_json
+    return @env_variables_json if @env_variables_json.present?
+    return "" if env_variables.empty?
+
+    env_variables.pluck(:key, :value).to_h.to_json
+  end
+
+  def env_variables_json=(value)
+    @env_variables_json = value
+    return if value.blank?
+
+    begin
+      parsed = JSON.parse(value)
+      env_variables.destroy_all
+      parsed.each do |key, val|
+        env_variables.build(key: key, value: val)
+      end
+    rescue JSON::ParserError
+      errors.add(:env_variables_json, "must be valid JSON")
+    end
+  end
 
   def secrets_hash
     secrets.pluck(:key, :value).to_h
@@ -19,7 +44,10 @@ class Project < ApplicationRecord
   end
 
   def env_strings
-    secrets.map { |secret| "#{secret.key}=#{secret.value}" }
+    vars = []
+    vars += env_variables.map { |env_var| "#{env_var.key}=#{env_var.value}" }
+    vars += secrets.map { |secret| "#{secret.key}=#{secret.value}" }
+    vars
   end
 
   private

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -40,6 +40,13 @@
     <small class="form-help">Container port to publish. Docker will assign an available host port automatically (default: 3000)</small>
   </div>
 
+  <%= render "shared/env_variables_fields", 
+             form: form, 
+             parent: @project, 
+             title: "Environment Variables",
+             singular_name: "Environment Variable",
+             help_text: "Set environment variables for the project." %>
+
   <%= render "shared/secrets_fields", 
              form: form, 
              parent: @project, 

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -40,6 +40,13 @@
     <small class="form-help">Container port to publish. Docker will assign an available host port automatically (default: 3000)</small>
   </div>
 
+  <%= render "shared/env_variables_fields", 
+             form: form, 
+             parent: @project, 
+             title: "Environment Variables",
+             singular_name: "Environment Variable",
+             help_text: "Set environment variables for the project." %>
+
   <div>
     <%= form.submit %>
   </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -23,6 +23,11 @@
 <h2>Setup Script</h2>
 <pre><code><%= @project.setup_script %></code></pre>
 
+<% if @project.env_variables.any? %>
+<h2>Environment Variables</h2>
+<p>Configured variables: <strong><%= @project.env_variables.pluck(:key).join(', ') %></strong></p>
+<% end %>
+
 <% if @project.secrets.any? %>
 <h2>Project Secrets</h2>
 <p>Configured secret keys: <strong><%= @project.secrets.pluck(:key).join(', ') %></strong></p>


### PR DESCRIPTION
## Summary
- Added environment variables support to projects, matching the existing implementation for agents
- Projects can now have both environment variables and secrets

## Changes
- Added `env_variables` polymorphic association to Project model
- Added `env_variables_json` attribute for JSON import/export functionality
- Updated projects controller to permit env_variables parameters
- Added environment variables UI to project new/edit forms using existing shared partial
- Updated project show page to display configured environment variables
- Modified `env_strings` method to include both env variables and secrets

🤖 Generated with [Claude Code](https://claude.ai/code)