### PR TITLE
Add branch selection to dashboard task form

### DIFF
--- a/app/javascript/controllers/branch_select_controller.js
+++ b/app/javascript/controllers/branch_select_controller.js
@@ -1,14 +1,35 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["select", "loading"]
+  static targets = ["select", "loading", "projectSelect"]
   static values = { projectId: Number }
   static classes = ["hidden"]
   
   connect() {
     // Set a default value immediately
     this.setDefaultBranch()
-    this.loadBranches()
+    
+    // If projectId is provided as a value (e.g., from new task page), load branches
+    if (this.projectIdValue) {
+      this.loadBranches()
+    }
+    // Otherwise check if there's a project already selected in the dropdown
+    else if (this.hasProjectSelectTarget && this.projectSelectTarget.value) {
+      this.projectIdValue = parseInt(this.projectSelectTarget.value)
+      this.loadBranches()
+    }
+  }
+  
+  projectChanged(event) {
+    const projectId = parseInt(event.target.value)
+    if (projectId) {
+      this.projectIdValue = projectId
+      this.selectTarget.disabled = false
+      this.loadBranches()
+    } else {
+      this.selectTarget.disabled = true
+      this.setDefaultBranch()
+    }
   }
   
   setDefaultBranch() {

--- a/app/views/tasks/_task_form.html.erb
+++ b/app/views/tasks/_task_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @task, local: true, class: "task-form", url: @project ? project_tasks_path(@project) : tasks_path) do |form| %>
+<%= form_with(model: @task, local: true, class: "task-form", url: @project ? project_tasks_path(@project) : tasks_path, data: { controller: "branch-select", branch_select_hidden_class: "_hidden" }) do |form| %>
   <% if @task.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
@@ -13,12 +13,18 @@
   <div class="selectors">
     <div class="field">
       <%= form.label :project_id, "Project" %><br>
-      <%= form.collection_select :project_id, @projects, :id, :name, { prompt: "Select a project" } %>
+      <%= form.collection_select :project_id, @projects, :id, :name, { prompt: "Select a project" }, { data: { action: "change->branch-select#projectChanged", branch_select_target: "projectSelect" } } %>
     </div>
 
     <div class="field">
       <%= form.label :agent_id, "Agent" %><br>
       <%= form.collection_select :agent_id, @agents, :id, :name, { prompt: "Select an agent" } %>
+    </div>
+
+    <div class="field">
+      <%= form.label :target_branch, "Target Branch" %><br>
+      <%= form.select :target_branch, [], {}, { data: { branch_select_target: "select" }, disabled: true } %>
+      <span data-branch-select-target="loading" class="_hidden">Loading branches...</span>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Added target branch selection field to the dashboard task form
- Users can now select a target branch when creating tasks from the dashboard
- Branch options are dynamically loaded when a project is selected

## Test plan
- [ ] Navigate to the dashboard
- [ ] Select a project from the dropdown
- [ ] Verify that the target branch field becomes enabled and loads available branches
- [ ] Create a task with a selected branch
- [ ] Verify the task is created with the correct target branch

🤖 Generated with [Claude Code](https://claude.ai/code)