### PR TITLE
Fix git apply command generation for whitespace handling

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,9 +69,10 @@ module ApplicationHelper
   end
 
   def git_apply_command(diff_content)
+    cleaned_diff = diff_content.lines.map(&:rstrip).join("\n")
     <<~COMMAND.strip
       (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF'
-      #{diff_content}
+      #{cleaned_diff}
       EOF
       )
     COMMAND

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,7 +70,7 @@ module ApplicationHelper
 
   def git_apply_command(diff_content)
     cleaned_diff = diff_content.lines.map(&:rstrip).join("\n").rstrip
-    %(cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
+    %(cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF'
 #{cleaned_diff}
 EOF
 )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,12 +69,10 @@ module ApplicationHelper
   end
 
   def git_apply_command(diff_content)
-    cleaned_diff = diff_content.lines.map(&:rstrip).join("\n")
-    <<~COMMAND.strip
-      (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF'
-      #{cleaned_diff}
-      EOF
-      )
-    COMMAND
+    cleaned_diff = diff_content.lines.map(&:rstrip).join("\n").rstrip
+    %(cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
+#{cleaned_diff}
+EOF
+)
   end
 end


### PR DESCRIPTION
## Summary
- Fix git apply command to strip trailing whitespace from diffs
- Match Codex's exact format for git apply commands
- Prevent "corrupt patch" errors when copying patches from SummonCircle

## Test plan
[x] Tests pass
[x] Linter passes with auto-fix
[x] Security static analysis passes
[ ] Manually test copying a git apply command from a task with trailing whitespace in the diff
[ ] Verify the copied command can be successfully applied in target projects

🤖 Generated with [Claude Code](https://claude.ai/code)