### PR TITLE
Expose DOCKER_URL environment variable to agent containers

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -162,7 +162,7 @@ class Run < ApplicationRecord
     Docker::Container.create(
       "Image" => agent.docker_image,
       "Cmd" => command,
-      "Env" => task.docker_env_strings,
+      "Env" => task.docker_env_strings(ENV.slice("DOCKER_URL")),
       "User" => agent.user_id.to_s,
       "WorkingDir" => task.agent.workplace_path,
       "HostConfig" => {

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -47,7 +47,14 @@ class Task < ApplicationRecord
   end
 
   def docker_env_strings(additional_vars = [])
-    agent.env_strings + project.env_strings + user.env_strings + additional_vars
+    additional_env_array = case additional_vars
+    when Hash
+      additional_vars.map { |k, v| "#{k}=#{v}" }
+    else
+      Array(additional_vars)
+    end
+    
+    agent.env_strings + project.env_strings + user.env_strings + additional_env_array
   end
 
   def latest_repo_state


### PR DESCRIPTION
## Summary
- Updated `Task#docker_env_strings` to accept hash parameters in addition to arrays
- Pass DOCKER_URL from host environment to agent containers using `ENV.slice("DOCKER_URL")`
- This allows agents to interact with the same Docker daemon as the host application

## Changes
1. Modified `Task#docker_env_strings` to handle both array and hash inputs
   - When a hash is passed, it converts it to Docker's expected format ("KEY=VALUE")
   - Uses `Array()` to handle other input types safely
2. Updated `Run#create_container` to pass DOCKER_URL using the cleaner `ENV.slice` approach

## Test plan
- [ ] Verify that agents can access Docker when DOCKER_URL is set
- [ ] Confirm existing functionality still works when DOCKER_URL is not set
- [ ] Test that other environment variables are still passed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)