### PR TITLE
Use DOCKER_HOST instead of DOCKER_URL for Docker endpoint exposure

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -162,7 +162,7 @@ class Run < ApplicationRecord
     Docker::Container.create(
       "Image" => agent.docker_image,
       "Cmd" => command,
-      "Env" => task.docker_env_strings(ENV.slice("DOCKER_URL")),
+      "Env" => task.docker_env_strings(ENV.slice("DOCKER_HOST")),
       "User" => agent.user_id.to_s,
       "WorkingDir" => task.agent.workplace_path,
       "HostConfig" => {

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -47,7 +47,7 @@ env:
     SOLID_QUEUE_IN_PUMA: true
 
     # Docker daemon URL for agent containers
-    DOCKER_URL: tcp://172.18.0.1:2375
+    DOCKER_HOST: tcp://172.18.0.1:2375
 
     # Enable proxy links and target containers directly when running in container
     CONTAINER_PROXY_LINKS: "1"

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -1,6 +1,6 @@
-# Configure global Docker URL if DOCKER_URL environment variable is set
-if ENV["DOCKER_URL"].present?
-  Docker.url = ENV["DOCKER_URL"]
+# Configure global Docker URL if DOCKER_HOST environment variable is set
+if ENV["DOCKER_HOST"].present?
+  Docker.url = ENV["DOCKER_HOST"]
   Docker.options = {
     read_timeout: 600,
     write_timeout: 600,

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     env_file:
       - ./secrets.env
     environment:
-      - DOCKER_URL=tcp://docker-proxy:2375
+      - DOCKER_HOST=tcp://docker-proxy:2375
       - MCP_SSE_ENDPOINT=http://summoncircle:3000
       - SOLID_QUEUE_IN_PUMA=1
     volumes:


### PR DESCRIPTION
## Summary
- Changed Docker endpoint environment variable from `DOCKER_URL` to `DOCKER_HOST` to follow Docker's standard naming convention
- Updated all references across the codebase to use the standard `DOCKER_HOST` environment variable
- This provides consistency with Docker's official environment variable naming

## Changes
- `config/initializers/docker.rb`: Updated to check for `DOCKER_HOST` instead of `DOCKER_URL`
- `app/models/run.rb`: Changed to pass `DOCKER_HOST` to agent containers
- `deploy/docker-compose.yml`: Updated production deployment to use `DOCKER_HOST`
- `config/deploy.yml`: Updated Kamal deployment configuration to use `DOCKER_HOST`

## Test plan
- [ ] Verify Docker connection works with `DOCKER_HOST` environment variable
- [ ] Test agent container creation still functions correctly
- [ ] Confirm production deployment works with the new environment variable

🤖 Generated with [Claude Code](https://claude.ai/code)