### PR TITLE
Fix proxy HTTP_HOST header to use localhost

### DIFF
--- a/config/initializers/container_proxy.rb
+++ b/config/initializers/container_proxy.rb
@@ -54,8 +54,8 @@ class ContainerProxy
 
           if host.present? && port.present?
             # Update the host for the proxy but keep the original path
-            env["HTTP_HOST"] = "#{host}:#{port}"
-            env["SERVER_NAME"] = host
+            env["HTTP_HOST"] = "localhost"
+            env["SERVER_NAME"] = "localhost"
             env["SERVER_PORT"] = port.to_s
 
             # Create a new proxy instance with the backend


### PR DESCRIPTION
## Summary
- Changed proxy to set HTTP_HOST and SERVER_NAME headers to "localhost"
- Backend URL remains correctly targeted to actual container host/port
- Ensures proxied applications receive consistent host headers

## Test plan
- [ ] Test proxy functionality with existing tasks
- [ ] Verify applications receive "localhost" as host header
- [ ] Confirm backend connections still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)