### PR TITLE
Add task description to page title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Summoncircle" %></title>
+    <title id="page-title"><%= content_for(:title) || "Summoncircle" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
@@ -27,7 +27,7 @@
 
   <body class="<%= controller_name %> <%= action_name %>">
     <%= content_for?(:nav) ? yield(:nav) : render("nav") %>
-    
+
     <main>
       <div id="flash-messages">
         <%= render 'flash_messages' %>

--- a/app/views/tasks/_description.html.erb
+++ b/app/views/tasks/_description.html.erb
@@ -1,3 +1,6 @@
 <%= turbo_frame_tag "task_#{task.id}_description" do %>
+  <turbo-stream action="update" target="page-title">
+    <template>Task: <%= task.description.presence || "Task ##{task.id}" %> - Summoncircle</template>
+  </turbo-stream>
   <%= link_to task.description.presence || "Task ##{task.id}", edit_task_path(task), style: "cursor: pointer; text-decoration: none; color: inherit;" %>
 <% end %>

--- a/app/views/tasks/_description.html.erb
+++ b/app/views/tasks/_description.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "task_#{task.id}_description" do %>
   <turbo-stream action="update" target="page-title">
-    <template>Task: <%= task.description.presence || "Task ##{task.id}" %> - Summoncircle</template>
+    <template><%= task.description.presence || "Task ##{task.id}" %> - Summoncircle</template>
   </turbo-stream>
   <%= link_to task.description.presence || "Task ##{task.id}", edit_task_path(task), style: "cursor: pointer; text-decoration: none; color: inherit;" %>
 <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "#{@task.description} - Summoncircle" %>
+
 <% if flash[:shrimp_mode] %>
   <div data-controller="shrimp-rain"></div>
 <% end %>


### PR DESCRIPTION
## Summary
- Added task description to the browser tab title on the task show page
- Title format: "[Task Description] - Summoncircle"
- Makes it easier to identify tasks when multiple tabs are open

## Test plan
1. Navigate to any task's show page
2. Check the browser tab title - it should display the task description followed by " - Summoncircle"
3. Open multiple task tabs to verify each shows its unique task description