### PR TITLE
Remove back buttons and add scroll-to-top functionality

### DIFF
--- a/app/assets/stylesheets/scroll-to-top.css
+++ b/app/assets/stylesheets/scroll-to-top.css
@@ -1,0 +1,39 @@
+.scroll-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: var(--accent);
+  color: white;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s, visibility 0.3s;
+  z-index: 1000;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.scroll-to-top:hover {
+  background-color: var(--accent-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.scroll-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (max-width: 768px) {
+  .scroll-to-top {
+    bottom: 15px;
+    right: 15px;
+    width: 45px;
+    height: 45px;
+    font-size: 20px;
+  }
+}

--- a/app/assets/stylesheets/scroll-to-top.css
+++ b/app/assets/stylesheets/scroll-to-top.css
@@ -28,6 +28,12 @@
   visibility: visible;
 }
 
+.panel-scroll-to-top {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+}
+
 @media (max-width: 768px) {
   .scroll-to-top {
     bottom: 15px;
@@ -35,5 +41,9 @@
     width: 45px;
     height: 45px;
     font-size: 20px;
+  }
+
+  .panel-scroll-to-top {
+    display: none;
   }
 }

--- a/app/javascript/controllers/scroll_to_top_controller.js
+++ b/app/javascript/controllers/scroll_to_top_controller.js
@@ -1,13 +1,39 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static values = { container: String }
+
   connect() {
+    this.scrollContainer = this.getScrollContainer()
     this.toggleVisibility()
-    window.addEventListener('scroll', this.handleScroll)
+
+    if (this.scrollContainer === window) {
+      window.addEventListener('scroll', this.handleScroll)
+    } else {
+      this.scrollContainer.addEventListener('scroll', this.handleScroll)
+    }
   }
 
   disconnect() {
-    window.removeEventListener('scroll', this.handleScroll)
+    if (this.scrollContainer === window) {
+      window.removeEventListener('scroll', this.handleScroll)
+    } else {
+      this.scrollContainer.removeEventListener('scroll', this.handleScroll)
+    }
+  }
+
+  getScrollContainer() {
+    if (!this.hasContainerValue) {
+      return window
+    }
+
+    if (this.containerValue === 'chat') {
+      return this.element.closest('.chat-panel')
+    } else if (this.containerValue === 'runs') {
+      return this.element.closest('.log-panel')
+    }
+
+    return window
   }
 
   handleScroll = () => {
@@ -15,7 +41,11 @@ export default class extends Controller {
   }
 
   toggleVisibility() {
-    if (window.scrollY > 300) {
+    const scrollTop = this.scrollContainer === window
+      ? window.scrollY
+      : this.scrollContainer.scrollTop
+
+    if (scrollTop > 300) {
       this.element.classList.add('visible')
     } else {
       this.element.classList.remove('visible')
@@ -23,9 +53,16 @@ export default class extends Controller {
   }
 
   scrollToTop() {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth'
-    })
+    if (this.scrollContainer === window) {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      })
+    } else {
+      this.scrollContainer.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      })
+    }
   }
 }

--- a/app/javascript/controllers/scroll_to_top_controller.js
+++ b/app/javascript/controllers/scroll_to_top_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.toggleVisibility()
+    window.addEventListener('scroll', this.handleScroll)
+  }
+
+  disconnect() {
+    window.removeEventListener('scroll', this.handleScroll)
+  }
+
+  handleScroll = () => {
+    this.toggleVisibility()
+  }
+
+  toggleVisibility() {
+    if (window.scrollY > 300) {
+      this.element.classList.add('visible')
+    } else {
+      this.element.classList.remove('visible')
+    }
+  }
+
+  scrollToTop() {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    })
+  }
+}

--- a/app/javascript/controllers/scroll_to_top_controller.js
+++ b/app/javascript/controllers/scroll_to_top_controller.js
@@ -1,65 +1,79 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = { container: String }
+  static targets = ["button", "container"]
 
   connect() {
-    this.scrollContainer = this.getScrollContainer()
-    this.toggleVisibility()
-
-    if (this.scrollContainer === window) {
-      window.addEventListener('scroll', this.handleScroll)
-    } else {
-      this.scrollContainer.addEventListener('scroll', this.handleScroll)
-    }
+    this.setupScrollListeners()
   }
 
   disconnect() {
-    if (this.scrollContainer === window) {
-      window.removeEventListener('scroll', this.handleScroll)
+    this.teardownScrollListeners()
+  }
+
+  setupScrollListeners() {
+    if (this.hasContainerTarget) {
+      this.containerTargets.forEach((container, index) => {
+        const button = this.buttonTargets[index]
+        if (button) {
+          const handleScroll = () => this.toggleVisibility(container, button)
+          container.addEventListener('scroll', handleScroll)
+          container._scrollHandler = handleScroll
+          this.toggleVisibility(container, button)
+        }
+      })
     } else {
-      this.scrollContainer.removeEventListener('scroll', this.handleScroll)
+      const handleScroll = () => this.toggleWindowVisibility()
+      window.addEventListener('scroll', handleScroll)
+      window._scrollHandler = handleScroll
+      this.toggleWindowVisibility()
     }
   }
 
-  getScrollContainer() {
-    if (!this.hasContainerValue) {
-      return window
+  teardownScrollListeners() {
+    if (this.hasContainerTarget) {
+      this.containerTargets.forEach(container => {
+        if (container._scrollHandler) {
+          container.removeEventListener('scroll', container._scrollHandler)
+          delete container._scrollHandler
+        }
+      })
+    } else {
+      if (window._scrollHandler) {
+        window.removeEventListener('scroll', window._scrollHandler)
+        delete window._scrollHandler
+      }
     }
-
-    if (this.containerValue === 'chat') {
-      return this.element.closest('.chat-panel')
-    } else if (this.containerValue === 'runs') {
-      return this.element.closest('.log-panel')
-    }
-
-    return window
   }
 
-  handleScroll = () => {
-    this.toggleVisibility()
+  toggleVisibility(container, button) {
+    if (container.scrollTop > 300) {
+      button.classList.add('visible')
+    } else {
+      button.classList.remove('visible')
+    }
   }
 
-  toggleVisibility() {
-    const scrollTop = this.scrollContainer === window
-      ? window.scrollY
-      : this.scrollContainer.scrollTop
-
-    if (scrollTop > 300) {
+  toggleWindowVisibility() {
+    if (window.scrollY > 300) {
       this.element.classList.add('visible')
     } else {
       this.element.classList.remove('visible')
     }
   }
 
-  scrollToTop() {
-    if (this.scrollContainer === window) {
-      window.scrollTo({
+  scrollToTop(event) {
+    const button = event.currentTarget
+    const index = this.buttonTargets.indexOf(button)
+
+    if (this.hasContainerTarget && index >= 0) {
+      const container = this.containerTargets[index]
+      container.scrollTo({
         top: 0,
         behavior: 'smooth'
       })
     } else {
-      this.scrollContainer.scrollTo({
+      window.scrollTo({
         top: 0,
         behavior: 'smooth'
       })

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -121,6 +121,5 @@
   <%= link_to 'Archive', agent_path(@agent), 
               data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this agent?' },
               class: 'archive' %> |
-  <%= link_to 'Clone', new_agent_path(source_id: @agent.id) %> |
-  <%= link_to 'Back', agents_path %>
+  <%= link_to 'Clone', new_agent_path(source_id: @agent.id) %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,5 +40,12 @@
         <%= current_git_branch || "unknown" %>
       </div>
     <% end %>
+    
+    <button data-controller="scroll-to-top" 
+            data-action="click->scroll-to-top#scrollToTop"
+            class="scroll-to-top" 
+            title="Scroll to top">
+      ↑
+    </button>
   </body>
 </html>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -38,6 +38,5 @@
   <%= link_to 'Edit', edit_project_path(@project), class: 'button' %> |
   <%= link_to 'Archive', project_path(@project), 
               data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this project?' },
-              class: 'archive' %> |
-  <%= link_to 'Back', projects_path %>
+              class: 'archive' %>
 </div>

--- a/app/views/tasks/_actions_header.html.erb
+++ b/app/views/tasks/_actions_header.html.erb
@@ -1,5 +1,8 @@
 <div class="task-actions-header" id="task-actions-header">
   <%= link_to 'Download Repository', task_repository_download_path(task), class: 'button', data: { turbo: false } %>
+  <%= link_to 'Archive', task_path(task),
+              data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this task?' },
+              class: 'button archive' %>
   <% if (repo_state = task.latest_repo_state) %>
     <% diff_content = repo_state.git_diff.presence || repo_state.target_branch_diff.presence || repo_state.uncommitted_diff %>
     <% if diff_content.present? %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -66,6 +66,5 @@
 <div class="task-actions">
   <%= link_to 'Archive', task_path(@task),
               data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this task?' },
-              class: 'archive' %> |
-  <%= link_to 'Back', project_tasks_path(@task.project) %>
+              class: 'archive' %>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -21,24 +21,23 @@
   </div>
 <% end %>
 
-<div data-controller="tabs resizable-panels" class="codex-layout">
+<div data-controller="tabs resizable-panels scroll-to-top" class="codex-layout">
   <%= turbo_stream_from @task %>
   <div class="nav">
     <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="chat" class="tab chat-tab">Chat</button>
     <button data-tabs-target="tab" data-action="click->tabs#switchTab" data-tab-panel="steps" class="tab -active">Runs</button>
   </div>
-  <div data-tabs-target="panel" data-resizable-panels-target="chat" data-panel-id="chat" class="chat-panel">
+  <div data-tabs-target="panel" data-resizable-panels-target="chat" data-panel-id="chat" data-scroll-to-top-target="container" class="chat-panel">
     <%= render "tasks/chat_panel", task: @task %>
-    <button data-controller="scroll-to-top"
+    <button data-scroll-to-top-target="button"
             data-action="click->scroll-to-top#scrollToTop"
-            data-scroll-to-top-container-value="chat"
             class="scroll-to-top panel-scroll-to-top"
             title="Scroll to top">
       ↑
     </button>
   </div>
   <div class="panel-divider" data-resizable-panels-target="divider" data-action="mousedown->resizable-panels#startResize"></div>
-  <div data-tabs-target="panel" data-resizable-panels-target="log" data-panel-id="steps" class="log-panel -active">
+  <div data-tabs-target="panel" data-resizable-panels-target="log" data-panel-id="steps" data-scroll-to-top-target="container" class="log-panel -active">
     <div id="runs-list" data-controller="auto-scroll">
       <% if @runs.any? %>
         <% @runs.each do |run| %>
@@ -67,9 +66,8 @@
         </div>
       <% end %>
     </div>
-    <button data-controller="scroll-to-top"
+    <button data-scroll-to-top-target="button"
             data-action="click->scroll-to-top#scrollToTop"
-            data-scroll-to-top-container-value="runs"
             class="scroll-to-top panel-scroll-to-top"
             title="Scroll to top">
       ↑

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -29,6 +29,13 @@
   </div>
   <div data-tabs-target="panel" data-resizable-panels-target="chat" data-panel-id="chat" class="chat-panel">
     <%= render "tasks/chat_panel", task: @task %>
+    <button data-controller="scroll-to-top"
+            data-action="click->scroll-to-top#scrollToTop"
+            data-scroll-to-top-container-value="chat"
+            class="scroll-to-top panel-scroll-to-top"
+            title="Scroll to top">
+      ↑
+    </button>
   </div>
   <div class="panel-divider" data-resizable-panels-target="divider" data-action="mousedown->resizable-panels#startResize"></div>
   <div data-tabs-target="panel" data-resizable-panels-target="log" data-panel-id="steps" class="log-panel -active">
@@ -60,11 +67,13 @@
         </div>
       <% end %>
     </div>
+    <button data-controller="scroll-to-top"
+            data-action="click->scroll-to-top#scrollToTop"
+            data-scroll-to-top-container-value="runs"
+            class="scroll-to-top panel-scroll-to-top"
+            title="Scroll to top">
+      ↑
+    </button>
   </div>
 </div>
 
-<div class="task-actions">
-  <%= link_to 'Archive', task_path(@task),
-              data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this task?' },
-              class: 'archive' %>
-</div>


### PR DESCRIPTION
## Summary
- Removed back buttons from task, project, and agent show pages to simplify navigation
- Added a floating scroll-to-top button that appears when scrolling down
- Implemented using Stimulus controller for proper Hotwire integration

## Implementation Details
- Created `scroll_to_top_controller.js` Stimulus controller
- Added `scroll-to-top.css` for button styling
- Button appears after scrolling 300px down
- Smooth scroll animation when clicked
- Responsive design (smaller size on mobile devices)
- Properly handles cleanup of event listeners on disconnect

## Test plan
- [ ] Navigate to task, project, and agent show pages
- [ ] Verify back buttons are removed
- [ ] Scroll down on any page more than 300px
- [ ] Verify scroll-to-top button appears
- [ ] Click the button and verify smooth scroll to top
- [ ] Test on mobile viewport to verify responsive sizing

🤖 Generated with [Claude Code](https://claude.ai/code)