### PR TITLE
Move archive button to the left in task show page

### DIFF
--- a/app/views/tasks/_actions_header.html.erb
+++ b/app/views/tasks/_actions_header.html.erb
@@ -1,8 +1,8 @@
 <div class="task-actions-header" id="task-actions-header">
-  <%= link_to 'Download Repository', task_repository_download_path(task), class: 'button', data: { turbo: false } %>
   <%= link_to 'Archive', task_path(task),
               data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to archive this task?' },
               class: 'button archive' %>
+  <%= link_to 'Download Repository', task_repository_download_path(task), class: 'button', data: { turbo: false } %>
   <% if (repo_state = task.latest_repo_state) %>
     <% diff_content = repo_state.git_diff.presence || repo_state.target_branch_diff.presence || repo_state.uncommitted_diff %>
     <% if diff_content.present? %>


### PR DESCRIPTION
## Summary
- Moved the archive button to the left side of the task actions header for better UI consistency
- Archive button now appears before the Download Repository button

## Test plan
- [ ] Visit a task show page
- [ ] Verify the archive button appears on the left side of the action buttons
- [ ] Test that the archive functionality still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)