### PR TITLE
Add syntax highlighting to diff viewer

### DIFF
--- a/app/javascript/controllers/diff_controller.js
+++ b/app/javascript/controllers/diff_controller.js
@@ -101,5 +101,6 @@ export default class extends Controller {
     })
     
     diff2htmlUi.draw()
+    diff2htmlUi.highlightCode()
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
     <link rel="apple-touch-icon" href="/icon.png">
 
     <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" media="screen and (prefers-color-scheme: light)" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css" media="screen and (prefers-color-scheme: dark)" />
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css" />
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
 

--- a/app/views/runs/_diff_panel.html.erb
+++ b/app/views/runs/_diff_panel.html.erb
@@ -16,6 +16,8 @@
   </div>
   <div data-diff-target="output">
     <template shadowrootmode="open">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" media="screen and (prefers-color-scheme: light)">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css" media="screen and (prefers-color-scheme: dark)">
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css">
       <div data-diff-target="shadowContent"></div>
     </template>


### PR DESCRIPTION
## Summary
- Integrated highlight.js with diff2html to enable syntax highlighting in code diffs
- Added support for both light and dark color schemes that automatically adapt to user preferences
- Ensured proper styling within shadow DOM isolation

## Test plan
- [ ] View a diff with code changes in various programming languages
- [ ] Verify syntax highlighting appears correctly in both side-by-side and line-by-line views
- [ ] Check that light/dark mode switching works properly
- [ ] Confirm no style conflicts with SimpleCss framework

🤖 Generated with [Claude Code](https://claude.ai/code)