### PR TITLE
Pass CONTAINER_PROXY_BASE_URL to agent containers

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -162,7 +162,7 @@ class Run < ApplicationRecord
     Docker::Container.create(
       "Image" => agent.docker_image,
       "Cmd" => command,
-      "Env" => task.docker_env_strings(ENV.slice("DOCKER_HOST")),
+      "Env" => task.docker_env_strings,
       "User" => agent.user_id.to_s,
       "WorkingDir" => task.agent.workplace_path,
       "HostConfig" => {

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -54,7 +54,12 @@ class Task < ApplicationRecord
       Array(additional_vars)
     end
 
-    agent.env_strings + project.env_strings + user.env_strings + additional_env_array
+    # Always include DOCKER_HOST and CONTAINER_PROXY_BASE_URL when they're set
+    system_env = []
+    system_env << "DOCKER_HOST=#{ENV['DOCKER_HOST']}" if ENV['DOCKER_HOST'].present?
+    system_env << "CONTAINER_PROXY_BASE_URL=#{ENV['CONTAINER_PROXY_BASE_URL']}" if ENV['CONTAINER_PROXY_BASE_URL'].present?
+
+    agent.env_strings + project.env_strings + user.env_strings + system_env + additional_env_array
   end
 
   def latest_repo_state


### PR DESCRIPTION
## Summary
- Updated `docker_env_strings` method to automatically include system environment variables
- Now passes `CONTAINER_PROXY_BASE_URL` and `DOCKER_HOST` to all agent containers when set
- Simplified code by removing redundant `ENV.slice` parameters

## Changes
1. **Modified `app/models/task.rb`**: Updated the `docker_env_strings` method to automatically include `DOCKER_HOST` and `CONTAINER_PROXY_BASE_URL` from the Rails environment when they're present
2. **Simplified `app/models/run.rb`**: Removed the `ENV.slice("DOCKER_HOST")` parameter since `docker_env_strings` now handles this automatically

This ensures that when `CONTAINER_PROXY_BASE_URL` is set in the Rails environment, it will be passed to all agent containers, enabling them to use proxy configurations if needed.

🤖 Generated with [Claude Code](https://claude.ai/code)