### PR TITLE
Pass CONTAINER_PROXY_BASE_URL as build arg when building dev containers

### DIFF
--- a/app/models/docker_container_builder.rb
+++ b/app/models/docker_container_builder.rb
@@ -111,10 +111,10 @@ class DockerContainerBuilder
 
     # Build context is the workspace root (where repo is cloned)
     tar_stream = create_tar_stream_from_directory(workspace_dir, @task.project.dev_dockerfile_path)
-    
+
     # Build with CONTAINER_PROXY_BASE_URL as build argument
     build_args = ENV.slice("CONTAINER_PROXY_BASE_URL")
-    
+
     Docker::Image.build_from_tar(tar_stream, t: image_name, dockerfile: @task.project.dev_dockerfile_path, buildargs: build_args)
   end
 

--- a/app/models/docker_container_builder.rb
+++ b/app/models/docker_container_builder.rb
@@ -111,7 +111,11 @@ class DockerContainerBuilder
 
     # Build context is the workspace root (where repo is cloned)
     tar_stream = create_tar_stream_from_directory(workspace_dir, @task.project.dev_dockerfile_path)
-    Docker::Image.build_from_tar(tar_stream, t: image_name, dockerfile: @task.project.dev_dockerfile_path)
+    
+    # Build with CONTAINER_PROXY_BASE_URL as build argument
+    build_args = ENV.slice("CONTAINER_PROXY_BASE_URL")
+    
+    Docker::Image.build_from_tar(tar_stream, t: image_name, dockerfile: @task.project.dev_dockerfile_path, buildargs: build_args)
   end
 
   def create_and_start_container(image_name, container_name)


### PR DESCRIPTION
## Summary
- Pass `CONTAINER_PROXY_BASE_URL` as a build argument when building dev containers for tasks
- This allows dev container Dockerfiles to access the proxy URL during build time using `ARG CONTAINER_PROXY_BASE_URL`

## Changes
- Modified `DockerContainerBuilder#build_docker_image` to pass `CONTAINER_PROXY_BASE_URL` from environment as a build argument
- Used `ENV.slice` for a clean implementation

## Test plan
- [ ] Build a dev container that uses `ARG CONTAINER_PROXY_BASE_URL` in its Dockerfile
- [ ] Verify the build argument is properly passed during container build
- [ ] Ensure existing container builds without this arg continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)