### PR TITLE
Add streaming build logs for Docker containers

### DIFF
--- a/app/controllers/build_logs_controller.rb
+++ b/app/controllers/build_logs_controller.rb
@@ -1,0 +1,44 @@
+class BuildLogsController < ApplicationController
+  include DockerStreamProcessor
+
+  before_action :set_task
+
+  def show
+    # If container is already built, try to fetch existing logs
+    if @task.container_status.in?([ "running", "exited", "failed" ])
+      @existing_logs = fetch_existing_logs
+    end
+  end
+
+  private
+
+  def set_task
+    @task = Task.find(params[:task_id])
+  end
+
+  def fetch_existing_logs
+    logs = []
+
+    # Try to get container logs if container exists
+    if @task.container_id.present?
+      begin
+        container = Docker::Container.get(@task.container_id)
+        container_logs = container.logs(stdout: true, stderr: true, timestamps: true)
+
+        if container_logs.present?
+          # Process Docker stream format using the included module
+          processed = process_docker_stream(container_logs)
+          logs = processed.split("\n").map(&:strip).reject(&:empty?)
+        end
+
+        Rails.logger.info "[BuildLogsController] Found #{logs.size} log lines for task #{@task.id}"
+      rescue Docker::Error::NotFoundError
+        Rails.logger.warn "[BuildLogsController] Container not found for task #{@task.id}"
+      rescue => e
+        Rails.logger.error "[BuildLogsController] Error fetching logs: #{e.message}"
+      end
+    end
+
+    logs
+  end
+end

--- a/app/models/docker_container_builder.rb
+++ b/app/models/docker_container_builder.rb
@@ -1,18 +1,31 @@
 require "open3"
 
 class DockerContainerBuilder
+  include DockerStreamProcessor
+
   def initialize(task)
     @task = task
   end
 
   def build_and_run
-    return unless @task.project.dev_dockerfile_path.present?
+    Rails.logger.info "[DockerContainerBuilder] Starting build_and_run for task #{@task.id}"
+
+    unless @task.project.dev_dockerfile_path.present?
+      Rails.logger.warn "[DockerContainerBuilder] No dockerfile path for task #{@task.id}"
+      return
+    end
+
+    # Broadcast initial status
+    Turbo::StreamsChannel.broadcast_append_to(
+      "task_#{@task.id}_build_logs",
+      target: "build-logs",
+      html: "<div class='log-entry info'>Initializing build process...</div>"
+    )
 
     # Clean up any existing container first (without broadcasting)
     remove_existing_container(broadcast: false)
 
     image_name = "summoncircle/task-#{@task.id}-dev"
-
     container_name = "task-#{@task.id}-dev-container-#{SecureRandom.hex(4)}"
 
     # Extract files from the workspace volume to build
@@ -20,12 +33,36 @@ class DockerContainerBuilder
     FileUtils.mkdir_p(temp_dir)
 
     begin
+      Rails.logger.info "[DockerContainerBuilder] Extracting workspace files for task #{@task.id}"
       extract_workspace_files(temp_dir)
+
+      Rails.logger.info "[DockerContainerBuilder] Building Docker image for task #{@task.id}"
       image = build_docker_image(temp_dir, image_name)
+
+      Rails.logger.info "[DockerContainerBuilder] Creating container for task #{@task.id}"
       container = create_and_start_container(image_name, container_name)
 
+      Rails.logger.info "[DockerContainerBuilder] Updating task info for task #{@task.id}"
       update_task_with_container_info(container, container_name, image)
       broadcast_docker_status
+
+      # Broadcast completion
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry success'>Container started successfully!</div>"
+      )
+    rescue => e
+      Rails.logger.error "[DockerContainerBuilder] Error for task #{@task.id}: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+
+      # Broadcast error
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry error'>Build failed: #{ERB::Util.html_escape(e.message)}</div>"
+      )
+      raise
     ensure
       FileUtils.rm_rf(temp_dir) if temp_dir && Dir.exist?(temp_dir)
     end
@@ -109,13 +146,80 @@ class DockerContainerBuilder
       raise "Dockerfile not found at: #{@task.project.dev_dockerfile_path}"
     end
 
+    # Check if image already exists
+    existing_image = nil
+    begin
+      existing_image = Docker::Image.get(image_name)
+      Rails.logger.info "[DockerContainerBuilder] Found existing image: #{image_name}"
+
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry warning'>Found existing Docker image: #{image_name}</div>"
+      )
+    rescue Docker::Error::NotFoundError
+      # Image doesn't exist, will need to build
+      Rails.logger.info "[DockerContainerBuilder] No existing image found, will build: #{image_name}"
+    end
+
+    # Broadcast build start
+    Turbo::StreamsChannel.broadcast_append_to(
+      "task_#{@task.id}_build_logs",
+      target: "build-logs",
+      html: "<div class='log-entry info'>Preparing Docker build context...</div>"
+    )
+
     # Build context is the workspace root (where repo is cloned)
     tar_stream = create_tar_stream_from_directory(workspace_dir, @task.project.dev_dockerfile_path)
 
     # Build with CONTAINER_PROXY_BASE_URL as build argument
     build_args = ENV.slice("CONTAINER_PROXY_BASE_URL").transform_values(&:to_s).to_json
 
-    Docker::Image.build_from_tar(tar_stream, t: image_name, dockerfile: @task.project.dev_dockerfile_path, buildargs: build_args)
+    Turbo::StreamsChannel.broadcast_append_to(
+      "task_#{@task.id}_build_logs",
+      target: "build-logs",
+      html: "<div class='log-entry info'>Starting Docker build...</div>"
+    )
+
+    # Stream build output with explicit streaming
+    begin
+      build_start = Time.current
+      event_count = 0
+
+      image = Docker::Image.build_from_tar(tar_stream,
+        t: image_name,
+        dockerfile: @task.project.dev_dockerfile_path,
+        buildargs: build_args,
+        nocache: false,
+        rm: true
+      ) do |event|
+        event_count += 1
+        # Process each event immediately
+        stream_build_log(event)
+
+        # Force flush to ensure immediate delivery
+        Rails.logger.flush if Rails.logger.respond_to?(:flush)
+      end
+
+      build_duration = Time.current - build_start
+      Rails.logger.info "[DockerContainerBuilder] Build completed in #{build_duration.round(2)}s with #{event_count} events"
+
+      # Broadcast build summary
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry info'>Build completed in #{build_duration.round(2)} seconds</div>"
+      )
+
+      image
+    rescue Docker::Error::UnexpectedResponseError => e
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry error'>Build error: #{ERB::Util.html_escape(e.message)}</div>"
+      )
+      raise
+    end
   end
 
   def create_and_start_container(image_name, container_name)
@@ -136,13 +240,25 @@ class DockerContainerBuilder
       }
     }
 
+    Rails.logger.info "[DockerContainerBuilder] Creating container with config: #{container_config.inspect}"
+
     container = Docker::Container.create(container_config)
     container.start
+
+    # Wait a moment and check if container is still running
+    sleep 0.5
+    container.refresh!
+
+    Rails.logger.info "[DockerContainerBuilder] Container status after start: #{container.info["State"]["Status"]}"
+
     container
   end
 
   def update_task_with_container_info(container, container_name, image)
     container_info = container.json
+
+    Rails.logger.info "[DockerContainerBuilder] Container state: #{container_info["State"]["Status"]}"
+    Rails.logger.info "[DockerContainerBuilder] Container running: #{container_info["State"]["Running"]}"
 
     @task.update!(
       container_id: container.id,
@@ -150,6 +266,34 @@ class DockerContainerBuilder
       container_status: container_info["State"]["Status"],
       docker_image_id: image.id
     )
+
+    # If container exited immediately, log why
+    if container_info["State"]["Status"] == "exited"
+      exit_code = container_info["State"]["ExitCode"]
+      Rails.logger.warn "[DockerContainerBuilder] Container exited with code #{exit_code}"
+
+      # Get container logs
+      logs = container.logs(stdout: true, stderr: true)
+      processed_logs = process_docker_stream(logs)
+
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry error'>Container exited immediately with code #{exit_code}</div>"
+      )
+
+      if processed_logs.present?
+        # Split logs into lines and format each one
+        processed_logs.split("\n").each do |line|
+          next if line.strip.empty?
+          Turbo::StreamsChannel.broadcast_append_to(
+            "task_#{@task.id}_build_logs",
+            target: "build-logs",
+            html: "<div class='log-entry'>#{ERB::Util.html_escape(line)}</div>"
+          )
+        end
+      end
+    end
   end
 
   def create_tar_stream_from_directory(dir, dockerfile_name = "Dockerfile")
@@ -184,5 +328,55 @@ class DockerContainerBuilder
       partial: "tasks/docker_controls",
       locals: { task: @task }
     )
+  end
+
+  def stream_build_log(event)
+    # Log timing for debugging
+    Rails.logger.info "[BUILD LOG] Received at #{Time.current.strftime('%H:%M:%S.%L')}: #{event.truncate(100)}"
+
+    # Parse the JSON event from Docker
+    parsed_event = JSON.parse(event) rescue { "stream" => event }
+
+    if parsed_event["stream"]
+      # Format the log entry
+      log_entry = parsed_event["stream"].strip
+      return if log_entry.empty?
+
+      # Determine the log entry type
+      css_class = case log_entry
+      when /error/i, /failed/i
+                    "error"
+      when /warning/i
+                    "warning"
+      when /step \d+\/\d+/i, /--->/i
+                    "info"
+      when /successfully/i, /complete/i
+                    "success"
+      else
+                    ""
+      end
+
+      # Broadcast to the build logs stream
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry #{css_class}'>#{ERB::Util.html_escape(log_entry)}</div>"
+      )
+    elsif parsed_event["error"]
+      # Handle errors
+      error_message = parsed_event["error"]
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry error'>ERROR: #{ERB::Util.html_escape(error_message)}</div>"
+      )
+    elsif parsed_event["aux"] && parsed_event["aux"]["ID"]
+      # Handle final build ID
+      Turbo::StreamsChannel.broadcast_append_to(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry success'>Build completed: #{ERB::Util.html_escape(parsed_event["aux"]["ID"])}</div>"
+      )
+    end
   end
 end

--- a/app/views/build_logs/show.html.erb
+++ b/app/views/build_logs/show.html.erb
@@ -1,0 +1,98 @@
+<%= turbo_stream_from "task_#{@task.id}_build_logs" %>
+
+<div class="container">
+  <div class="card">
+    <div class="card-header">
+      <h2>Build Logs for <%= @task.description %></h2>
+      <div class="card-actions">
+        <%= link_to "Back to Task", task_path(@task), class: "button secondary" %>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="build-log-console">
+        <div id="build-logs" class="log-output">
+          <% if @task.container_status == "building" %>
+            <div class="log-entry" id="initial-message">Connecting to build stream...</div>
+          <% elsif @task.container_status == "failed" %>
+            <div class="log-entry error">Build failed. Build logs may appear below if available.</div>
+          <% elsif @task.container_status == "running" %>
+            <div class="log-entry success">Build completed successfully. Container is running.</div>
+          <% elsif @task.container_status == "exited" %>
+            <div class="log-entry warning">Container has exited. Check logs below for details.</div>
+          <% else %>
+            <div class="log-entry">Waiting for build to start...</div>
+          <% end %>
+
+          <% if @existing_logs.present? %>
+            <% @existing_logs.each do |log_line| %>
+              <div class="log-entry"><%= log_line %></div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .build-log-console {
+    background-color: #1e1e1e;
+    border-radius: 4px;
+    padding: 1rem;
+    min-height: 400px;
+    max-height: 600px;
+    overflow-y: auto;
+    font-family: 'Courier New', monospace;
+  }
+
+  .log-output {
+    color: #d4d4d4;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .log-entry {
+    margin-bottom: 0.25rem;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 13px;
+  }
+
+  .log-entry.error {
+    color: #f48771;
+  }
+
+  .log-entry.success {
+    color: #89d185;
+  }
+
+  .log-entry.info {
+    color: #61afef;
+  }
+
+  .log-entry.warning {
+    color: #e5c07b;
+  }
+</style>
+
+<script>
+  document.addEventListener('turbo:load', () => {
+    const buildLogs = document.getElementById('build-logs');
+    if (!buildLogs) return;
+
+    // Auto-scroll to bottom on new log entries
+    const observer = new MutationObserver(() => {
+      // Remove initial message if it exists
+      const initialMessage = document.getElementById('initial-message');
+      if (initialMessage) {
+        initialMessage.remove();
+      }
+
+      // Scroll to bottom
+      const console = buildLogs.parentElement;
+      console.scrollTop = console.scrollHeight;
+    });
+
+    observer.observe(buildLogs, { childList: true });
+  });
+</script>

--- a/app/views/tasks/_docker_controls.html.erb
+++ b/app/views/tasks/_docker_controls.html.erb
@@ -1,11 +1,14 @@
 <div id="docker_controls" class="docker-controls">
   <% container_info = container_status_info(task) %>
-  
+
   <% if task.container_status == "building" %>
     <div class="container-info">
       <span class="container-status">
         Container: Building...
       </span>
+      <%= link_to "View Build Logs", task_build_log_path(task),
+          target: "_blank",
+          class: "button action-button -mini -primary" %>
     </div>
   <% elsif task.container_status == "removing" %>
     <div class="container-info">
@@ -18,7 +21,10 @@
       <span class="container-status -error">
         Container: Build Failed
       </span>
-      <%= link_to "Retry Build", task_container_path(task), 
+      <%= link_to "View Build Logs", task_build_log_path(task),
+          target: "_blank",
+          class: "button action-button -mini" %>
+      <%= link_to "Retry Build", task_container_path(task),
           data: { turbo_method: :post },
           class: "button action-button -mini -primary" %>
     </div>
@@ -33,15 +39,18 @@
           | Port: <%= task.project.dev_container_port %> (not mapped)
         <% end %>
       </span>
-      <%= link_to "Build", task_container_path(task), 
+      <%= link_to "View Build Logs", task_build_log_path(task),
+          target: "_blank",
+          class: "button action-button -mini" %>
+      <%= link_to "Build", task_container_path(task),
           data: { turbo_method: :post, turbo_confirm: "Build container?" },
           class: "button action-button -mini" %>
-      <%= link_to "Remove", task_container_path(task), 
+      <%= link_to "Remove", task_container_path(task),
           data: { turbo_method: :delete, turbo_confirm: "Remove container?" },
           class: "button action-button -mini -danger" %>
     </div>
   <% else %>
-    <%= link_to "Build & Run Container", task_container_path(task), 
+    <%= link_to "Build & Run Container", task_container_path(task),
         data: { turbo_method: :post },
         class: "button action-button -primary -mini",
         title: "Build and run a development container with the project's Dockerfile" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         patch :update_auto_push
       end
       resource :container, only: %i[create destroy]
+      resource :build_log, only: %i[show]
       resources :runs, only: %i[create]
     end
   end

--- a/test/controllers/build_logs_controller_test.rb
+++ b/test/controllers/build_logs_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class BuildLogsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:two)  # Use standard user, not admin
+    @task = tasks(:two)
+    login @user
+  end
+
+  test "should get show for own task" do
+    get task_build_log_url(@task)
+    assert_response :success
+  end
+
+  test "should access any task build logs when authenticated" do
+    other_user_task = tasks(:one)  # This belongs to user one
+
+    # Verify the task belongs to a different user
+    assert_not_equal @user.id, other_user_task.user_id
+
+    # Log in as user two and access user one's task - should work
+    get task_build_log_url(other_user_task)
+    assert_response :success
+  end
+
+  test "should redirect to login when not authenticated" do
+    logout
+    get task_build_log_url(@task)
+    assert_redirected_to new_session_path
+  end
+end

--- a/test/models/docker_container_builder_test.rb
+++ b/test/models/docker_container_builder_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class DockerContainerBuilderTest < ActiveSupport::TestCase
+  setup do
+    @task = tasks(:one)
+    @builder = DockerContainerBuilder.new(@task)
+  end
+
+  test "stream_build_log broadcasts Docker build events" do
+    build_event = { "stream" => "Step 1/5 : FROM ruby:3.0\n" }.to_json
+
+    Turbo::StreamsChannel.expects(:broadcast_append_to).with(
+      "task_#{@task.id}_build_logs",
+      target: "build-logs",
+      html: "<div class='log-entry info'>Step 1/5 : FROM ruby:3.0</div>"
+    )
+
+    @builder.send(:stream_build_log, build_event)
+  end
+
+  test "stream_build_log handles error events" do
+    error_event = { "error" => "Cannot connect to Docker daemon" }.to_json
+
+    Turbo::StreamsChannel.expects(:broadcast_append_to).with(
+      "task_#{@task.id}_build_logs",
+      target: "build-logs",
+      html: "<div class='log-entry error'>ERROR: Cannot connect to Docker daemon</div>"
+    )
+
+    @builder.send(:stream_build_log, error_event)
+  end
+
+  test "stream_build_log applies correct CSS classes" do
+    test_cases = [
+      [ { "stream" => "ERROR: Build failed\n" }.to_json, "error", "ERROR: Build failed" ],
+      [ { "stream" => "WARNING: Deprecated command\n" }.to_json, "warning", "WARNING: Deprecated command" ],
+      [ { "stream" => "Step 2/5 : RUN bundle install\n" }.to_json, "info", "Step 2/5 : RUN bundle install" ],
+      [ { "stream" => "---> Using cache\n" }.to_json, "info", "---&gt; Using cache" ],
+      [ { "stream" => "Successfully built abcd1234\n" }.to_json, "success", "Successfully built abcd1234" ],
+      [ { "stream" => "Build complete!\n" }.to_json, "success", "Build complete!" ],
+      [ { "stream" => "Regular output\n" }.to_json, "", "Regular output" ]
+    ]
+
+    test_cases.each do |event_json, expected_class, expected_text|
+      css_class = expected_class.empty? ? " " : " #{expected_class}"
+      Turbo::StreamsChannel.expects(:broadcast_append_to).with(
+        "task_#{@task.id}_build_logs",
+        target: "build-logs",
+        html: "<div class='log-entry#{css_class}'>#{expected_text}</div>"
+      )
+      @builder.send(:stream_build_log, event_json)
+    end
+  end
+
+  test "stream_build_log ignores empty streams" do
+    empty_event = { "stream" => "\n" }.to_json
+
+    # Should not broadcast anything for empty streams
+    Turbo::StreamsChannel.expects(:broadcast_append_to).never
+
+    @builder.send(:stream_build_log, empty_event)
+  end
+
+  test "stream_build_log handles malformed JSON" do
+    malformed_json = "not valid json"
+
+    Turbo::StreamsChannel.expects(:broadcast_append_to).with(
+      "task_#{@task.id}_build_logs",
+      target: "build-logs",
+      html: "<div class='log-entry '>not valid json</div>"
+    )
+
+    @builder.send(:stream_build_log, malformed_json)
+  end
+end


### PR DESCRIPTION
## Summary
- Implemented real-time streaming build logs for Docker container builds
- Added a dedicated build logs view with console-style interface
- Enhanced error handling and container status tracking

## Changes
- Created `BuildLogsController` to handle build log display
- Added `/tasks/:task_id/build_log` route for viewing logs
- Enhanced `DockerContainerBuilder` to capture and stream Docker build output via Turbo Streams
- Added "View Build Logs" buttons in task view for all container states (building, failed, running)
- Implemented auto-scrolling console view with color-coded log entries
- Added support for viewing historical logs for containers that have already been built
- Comprehensive test coverage for build log streaming functionality

## Technical Details
- Uses Turbo Streams for real-time log updates without page refresh
- Processes Docker's JSON stream format for build events
- Handles container exit status and displays container logs when containers exit immediately
- Includes enhanced logging for debugging build issues

## Known Issues
- Docker build logs may appear all at once at the end due to Docker API buffering behavior
- Container might exit immediately if no long-running process is defined in the Dockerfile

🤖 Generated with [Claude Code](https://claude.ai/code)