### PR TITLE
Add GitLab token support

### DIFF
--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -15,6 +15,10 @@ class UserSettingsController < ApplicationController
       user_update_params.delete(:github_token)
     end
 
+    if user_update_params[:gitlab_token].blank?
+      user_update_params.delete(:gitlab_token)
+    end
+
     if user_update_params[:ssh_key].blank?
       user_update_params.delete(:ssh_key)
     end
@@ -29,6 +33,6 @@ class UserSettingsController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:github_token, :ssh_key, :instructions, :git_config, :allow_github_token_access, :shrimp_mode, :auto_task_naming_agent_id)
+    params.require(:user).permit(:github_token, :gitlab_token, :ssh_key, :instructions, :git_config, :allow_github_token_access, :allow_gitlab_token_access, :shrimp_mode, :auto_task_naming_agent_id)
   end
 end

--- a/app/models/docker_git_command.rb
+++ b/app/models/docker_git_command.rb
@@ -134,6 +134,8 @@ class DockerGitCommand
     case url
     when /github\.com/
       :github
+    when /gitlab\.com/
+      :gitlab
     else
       nil
     end
@@ -147,6 +149,13 @@ class DockerGitCommand
         username: "x-access-token",
         env_var: "GITHUB_TOKEN",
         token: user.github_token
+      }
+    when :gitlab
+      return nil unless user&.gitlab_token.present?
+      {
+        username: "oauth2",
+        env_var: "GITLAB_TOKEN",
+        token: user.gitlab_token
       }
     else
       nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   belongs_to :auto_task_naming_agent, class_name: "Agent", optional: true
 
   encrypts :github_token, deterministic: false
+  encrypts :gitlab_token, deterministic: false
   encrypts :ssh_key, deterministic: false
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
@@ -13,6 +14,7 @@ class User < ApplicationRecord
   def env_strings
     vars = []
     vars << "GITHUB_TOKEN=#{github_token}" if github_token.present? && allow_github_token_access
+    vars << "GITLAB_TOKEN=#{gitlab_token}" if gitlab_token.present? && allow_gitlab_token_access
     vars
   end
 end

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -16,6 +16,18 @@
   </div>
 
   <div>
+    <%= form.label :gitlab_token, "GitLab Personal Access Token" %><br>
+    <%= form.password_field :gitlab_token, placeholder: "Leave blank to keep current token" %>
+    <small>Used to clone private GitLab repositories. Token is encrypted and never displayed.</small>
+  </div>
+
+  <div>
+    <%= form.check_box :allow_gitlab_token_access %>
+    <%= form.label :allow_gitlab_token_access, "Allow tasks to have access to my GitLab token" %><br>
+    <small>When checked, tasks can use your GitLab token for Git operations. Uncheck to prevent tasks from accessing your token.</small>
+  </div>
+
+  <div>
     <%= form.label :ssh_key, "SSH Private Key" %><br>
     <%= form.text_area :ssh_key, rows: 10, placeholder: "Paste your SSH private key here (leave blank to keep current key)", value: "" %>
     <small>Used for Git authentication. Key is encrypted and automatically mounted in containers. Never displayed or logged.</small>
@@ -40,7 +52,7 @@
 
   <div>
     <%= form.label :auto_task_naming_agent_id, "Auto Task Naming Agent" %><br>
-    <%= form.select :auto_task_naming_agent_id, 
+    <%= form.select :auto_task_naming_agent_id,
         options_from_collection_for_select(Agent.kept, :id, :name, @user.auto_task_naming_agent_id),
         { include_blank: "None - Manual task naming only" },
         { class: "form-select" } %>

--- a/app/views/user_settings/show.html.erb
+++ b/app/views/user_settings/show.html.erb
@@ -14,7 +14,7 @@
 </div>
 
 <div>
-  <strong>GitHub Token:</strong> 
+  <strong>GitHub Token:</strong>
   <% if @user.github_token.present? %>
     ••••••••••••••••
   <% else %>
@@ -23,8 +23,22 @@
 </div>
 
 <div>
-  <strong>Allow tasks to access GitHub token:</strong> 
+  <strong>Allow tasks to access GitHub token:</strong>
   <%= @user.allow_github_token_access ? "Yes" : "No" %>
+</div>
+
+<div>
+  <strong>GitLab Token:</strong>
+  <% if @user.gitlab_token.present? %>
+    ••••••••••••••••
+  <% else %>
+    Not set
+  <% end %>
+</div>
+
+<div>
+  <strong>Allow tasks to access GitLab token:</strong>
+  <%= @user.allow_gitlab_token_access ? "Yes" : "No" %>
 </div>
 
 <div>

--- a/db/migrate/20250812201945_add_gitlab_token_to_users.rb
+++ b/db/migrate/20250812201945_add_gitlab_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddGitlabTokenToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :gitlab_token, :text
+    add_column :users, :allow_gitlab_token_access, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_25_002158) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_12_201945) do
   create_table "agent_specific_settings", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.string "type", null: false
@@ -167,6 +167,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_25_002158) do
     t.boolean "allow_github_token_access", default: true, null: false
     t.boolean "shrimp_mode", default: true, null: false
     t.integer "auto_task_naming_agent_id"
+    t.text "gitlab_token"
+    t.boolean "allow_gitlab_token_access", default: true, null: false
     t.index [ "auto_task_naming_agent_id" ], name: "index_users_on_auto_task_naming_agent_id"
     t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
   end


### PR DESCRIPTION
## Summary
- Added support for GitLab personal access tokens alongside existing GitHub tokens
- Users can now configure both GitHub and GitLab tokens for accessing private repositories
- Tokens are encrypted and can be independently enabled/disabled for task access

## Changes
- Added  and  fields to users table
- Updated User model to encrypt GitLab tokens and include them in environment variables
- Extended UserSettingsController to handle GitLab token parameters
- Added GitLab token configuration fields to user settings views
- Updated DockerGitCommand to support GitLab authentication (oauth2 username)
- Both GitHub and GitLab tokens work with their respective platforms for Git operations